### PR TITLE
fix(plugin-ai): render business report charts

### DIFF
--- a/packages/plugins/@nocobase/plugin-ai/src/client-v2/__tests__/business-report-card.test.tsx
+++ b/packages/plugins/@nocobase/plugin-ai/src/client-v2/__tests__/business-report-card.test.tsx
@@ -8,9 +8,10 @@
  */
 
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { BusinessReportCard } from '../ai-employees/tools/BusinessReportCard';
+import { Markdown } from '../ai-employees/chatbox/components/Markdown';
 
 const mocks = vi.hoisted(() => ({
   chatState: {
@@ -24,6 +25,18 @@ const mocks = vi.hoisted(() => ({
 vi.mock('../locale', () => ({
   useT: () => (text: string) => text,
 }));
+
+vi.mock('echarts-for-react', () => ({
+  default: React.forwardRef(() => <div data-testid="echarts" />),
+}));
+
+vi.mock('@nocobase/client-v2', async () => {
+  const actual = await vi.importActual<typeof import('@nocobase/client-v2')>('@nocobase/client-v2');
+  return {
+    ...actual,
+    useGlobalTheme: () => ({ isDarkTheme: false }),
+  };
+});
 
 vi.mock('../ai-employees/chatbox/hooks/useChat', () => ({
   useChat: () => ({
@@ -123,5 +136,19 @@ describe('BusinessReportCard', () => {
         invokeStatus: 'done',
       }),
     );
+  });
+});
+
+describe('business report markdown', () => {
+  it('renders an embedded chart without treating a memo component as a function', () => {
+    render(
+      <Markdown message={{ messageId: 'report-message', content: '' }}>
+        {
+          '<echarts>{"xAxis":{"type":"category","data":["Jan","Feb"]},"yAxis":{"type":"value"},"series":[{"type":"bar","data":[100,150]}]}</echarts>'
+        }
+      </Markdown>,
+    );
+
+    expect(screen.getByTestId('echarts')).toBeInTheDocument();
   });
 });

--- a/packages/plugins/@nocobase/plugin-ai/src/client-v2/ai-employees/chatbox/components/Markdown.tsx
+++ b/packages/plugins/@nocobase/plugin-ai/src/client-v2/ai-employees/chatbox/components/Markdown.tsx
@@ -406,134 +406,132 @@ class EchartsErrorBoundary extends React.Component<
   }
 }
 
-const Echarts: React.FC<EchartsProps> = observer(
-  React.memo(
-    ({ children, message, ...rest }) => {
-      const chartRef = useRef<ReactECharts>(null);
-      const containerRef = useRef<HTMLDivElement>(null);
-      const { token } = theme.useToken();
-      const { isDarkTheme } = useGlobalTheme();
-      const t = useT();
-      const runtime = useChatBoxRuntime();
-      const currentConversation = runtime.chatConversationModel.currentConversation;
-      const chat = useChat(currentConversation, runtime);
-      const responseLoading = chat.use.responseLoading();
-      const optionSource = React.Children.toArray(children).join('');
-      let option: Record<string, unknown> = {};
-      let optionValid = true;
+const Echarts: React.FC<EchartsProps> = React.memo(
+  observer(function EchartsObserver({ children, message, ...rest }) {
+    const chartRef = useRef<ReactECharts>(null);
+    const containerRef = useRef<HTMLDivElement>(null);
+    const { token } = theme.useToken();
+    const { isDarkTheme } = useGlobalTheme();
+    const t = useT();
+    const runtime = useChatBoxRuntime();
+    const currentConversation = runtime.chatConversationModel.currentConversation;
+    const chat = useChat(currentConversation, runtime);
+    const responseLoading = chat.use.responseLoading();
+    const optionSource = React.Children.toArray(children).join('');
+    let option: Record<string, unknown> = {};
+    let optionValid = true;
 
-      try {
-        option = JSON.parse(optionSource) as Record<string, unknown>;
-      } catch (error) {
-        optionValid = false;
-      }
+    try {
+      option = JSON.parse(optionSource) as Record<string, unknown>;
+    } catch (error) {
+      optionValid = false;
+    }
 
-      useEffect(() => {
-        if (!optionValid) {
-          return;
-        }
-
-        const resizeChart = () => {
-          chartRef.current?.getEchartsInstance()?.resize();
-        };
-        const timeouts = [0, 100, 300].map((delay) => window.setTimeout(resizeChart, delay));
-        const observer =
-          typeof ResizeObserver !== 'undefined' && containerRef.current
-            ? new ResizeObserver(() => {
-                resizeChart();
-              })
-            : null;
-
-        if (observer && containerRef.current) {
-          observer.observe(containerRef.current);
-        }
-
-        return () => {
-          timeouts.forEach((timeoutId) => window.clearTimeout(timeoutId));
-          observer?.disconnect();
-        };
-      }, [optionSource, optionValid]);
-
-      if (responseLoading && !message?.messageId) {
-        return <Spin size="small" tip={t('Generating')} />;
-      }
-
+    useEffect(() => {
       if (!optionValid) {
-        return (
-          <Card
-            size="small"
-            title={t('ECharts')}
-            styles={{
-              title: {
-                fontSize: token.fontSize,
-                fontWeight: 400,
-              },
-              body: {
-                width: '100%',
-                fontSize: token.fontSizeSM,
-              },
-            }}
-          >
-            <SyntaxHighlighter {...rest} PreTag="div" language="json" style={isDarkTheme ? dark : defaultStyle}>
-              {optionSource.replace(/\n$/, '')}
-            </SyntaxHighlighter>
-          </Card>
-        );
+        return;
       }
 
+      const resizeChart = () => {
+        chartRef.current?.getEchartsInstance()?.resize();
+      };
+      const timeouts = [0, 100, 300].map((delay) => window.setTimeout(resizeChart, delay));
+      const observer =
+        typeof ResizeObserver !== 'undefined' && containerRef.current
+          ? new ResizeObserver(() => {
+              resizeChart();
+            })
+          : null;
+
+      if (observer && containerRef.current) {
+        observer.observe(containerRef.current);
+      }
+
+      return () => {
+        timeouts.forEach((timeoutId) => window.clearTimeout(timeoutId));
+        observer?.disconnect();
+      };
+    }, [optionSource, optionValid]);
+
+    if (responseLoading && !message?.messageId) {
+      return <Spin size="small" tip={t('Generating')} />;
+    }
+
+    if (!optionValid) {
       return (
-        <EchartsErrorBoundary
-          resetKey={optionSource}
-          fallback={(error) =>
-            responseLoading ? null : (
-              <Alert showIcon type="error" message={t('Invalid chart options')} description={error.message} />
-            )
-          }
+        <Card
+          size="small"
+          title={t('ECharts')}
+          styles={{
+            title: {
+              fontSize: token.fontSize,
+              fontWeight: 400,
+            },
+            body: {
+              width: '100%',
+              fontSize: token.fontSizeSM,
+            },
+          }}
         >
-          <div ref={containerRef}>
-            <ReactECharts
-              ref={chartRef}
-              echarts={echarts}
-              option={{
-                ...option,
-                toolbox: {
-                  show: true,
-                  feature: {
-                    saveAsImage: {
-                      title: t('Save as image'),
-                      icon: `path://${downloadIconPath}`,
+          <SyntaxHighlighter {...rest} PreTag="div" language="json" style={isDarkTheme ? dark : defaultStyle}>
+            {optionSource.replace(/\n$/, '')}
+          </SyntaxHighlighter>
+        </Card>
+      );
+    }
+
+    return (
+      <EchartsErrorBoundary
+        resetKey={optionSource}
+        fallback={(error) =>
+          responseLoading ? null : (
+            <Alert showIcon type="error" message={t('Invalid chart options')} description={error.message} />
+          )
+        }
+      >
+        <div ref={containerRef}>
+          <ReactECharts
+            ref={chartRef}
+            echarts={echarts}
+            option={{
+              ...option,
+              toolbox: {
+                show: true,
+                feature: {
+                  saveAsImage: {
+                    title: t('Save as image'),
+                    icon: `path://${downloadIconPath}`,
+                    iconStyle: {
+                      fontSize: token.fontSizeSM,
+                      color: token.colorText,
+                      borderWidth: 0,
+                    },
+                    emphasis: {
                       iconStyle: {
                         fontSize: token.fontSizeSM,
-                        color: token.colorText,
+                        color: token.colorLinkHover,
                         borderWidth: 0,
-                      },
-                      emphasis: {
-                        iconStyle: {
-                          fontSize: token.fontSizeSM,
-                          color: token.colorLinkHover,
-                          borderWidth: 0,
-                        },
                       },
                     },
                   },
                 },
-              }}
-              theme={isDarkTheme ? 'dark' : 'default'}
-            />
-          </div>
-        </EchartsErrorBoundary>
-      );
-    },
-    (previous, next) => {
-      const previousChildren = React.Children.toArray(previous.children).join('');
-      const nextChildren = React.Children.toArray(next.children).join('');
-      return (
-        previousChildren === nextChildren &&
-        previous.message?.messageId === next.message?.messageId &&
-        previous.index === next.index
-      );
-    },
-  ),
+              },
+            }}
+            theme={isDarkTheme ? 'dark' : 'default'}
+          />
+        </div>
+      </EchartsErrorBoundary>
+    );
+  }),
+  (previous, next) => {
+    const previousChildren = React.Children.toArray(previous.children).join('');
+    const nextChildren = React.Children.toArray(next.children).join('');
+    return (
+      previousChildren === nextChildren &&
+      previous.message?.messageId === next.message?.messageId &&
+      previous.index === next.index
+    );
+  },
 );
 
 Echarts.displayName = 'Echarts';


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Business analysis reports containing ECharts failed to open in the report modal with `Invalid report definition` and `component is not a function`.

The chart renderer passed a `React.memo` exotic component into the FlowEngine `observer`, which expects a callable function component.

### Description

- Apply `observer` to the ECharts function component before wrapping it with `React.memo`.
- Preserve the existing memo comparison behavior for chart content and message identity.
- Add a regression test that renders an embedded `<echarts>` block through the business report Markdown renderer.

Risk is limited to the AI employee Markdown ECharts component wrapper. Text-only report rendering and ECharts options remain unchanged.

Testing suggestions:

- Generate a business analysis report containing one or more charts and open the report modal.
- Confirm the chart renders without the invalid report error.
- Confirm text-only reports and historical report cards continue to work.

### Related issues


### Showcase


### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed an error that prevented business analysis reports containing charts from opening. |
| 🇨🇳 Chinese | 修复包含图表的业务分析报告无法打开的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Documentation update not needed |
| 🇨🇳 Chinese | 无需更新文档 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
