### PR TITLE
fix(client-v2): preserve date presets in field assignments

### DIFF
--- a/packages/core/client-v2/src/flow/components/field-value-variable/FieldValueVariableInput.tsx
+++ b/packages/core/client-v2/src/flow/components/field-value-variable/FieldValueVariableInput.tsx
@@ -299,8 +299,7 @@ export const FieldValueVariableInput: React.FC<FieldValueVariableInputProps> = (
           return null;
         },
         resolveValueFromPath: (item) => {
-          const external = converters?.resolveValueFromPath?.(item);
-          if (external !== undefined) return external;
+          // Synthetic field-value nodes own their value shapes. Domain converters only serialize nodes from baseMetaTree.
           const firstPath = item?.paths?.[0];
           if (firstPath === 'constant') return '';
           if (firstPath === 'null') return null;
@@ -308,7 +307,7 @@ export const FieldValueVariableInput: React.FC<FieldValueVariableInputProps> = (
             return createInitialDateConfig(item.paths[1], isDateLikeField, dateComponentProps);
           }
           if (allowRunJS && firstPath === 'runjs') return { code: '', version: 'v2' };
-          return undefined;
+          return converters?.resolveValueFromPath?.(item);
         },
         resolvePathFromValue: (currentValue) => {
           const external = converters?.resolvePathFromValue?.(currentValue);

--- a/packages/core/client-v2/src/flow/components/field-value-variable/__tests__/FieldValueVariableInput.test.tsx
+++ b/packages/core/client-v2/src/flow/components/field-value-variable/__tests__/FieldValueVariableInput.test.tsx
@@ -50,6 +50,7 @@ function renderInput(options?: {
   value?: unknown;
   isDateLikeField?: boolean;
   dateComponentProps?: DateVariableComponentProps;
+  converters?: VariableInputProps['converters'];
 }) {
   const onChange = vi.fn();
   render(
@@ -62,6 +63,7 @@ function renderInput(options?: {
       runJSComponent={RunJSComponent}
       isDateLikeField={options?.isDateLikeField ?? false}
       dateComponentProps={options?.dateComponentProps ?? DEFAULT_DATE_VARIABLE_COMPONENT_PROPS}
+      converters={options?.converters}
     />,
   );
   return onChange;
@@ -259,6 +261,36 @@ describe('FieldValueVariableInput', () => {
     mocks.variableInputProps?.onChange?.(mocks.variableInputProps.value);
     expect(mocks.variableInputProps?.value).toMatchObject({ kind: 'preset', preset: 'today', format: 'YYYY/MM/DD' });
     expect(formattedOnChange).not.toHaveBeenCalled();
+  });
+
+  it('keeps Date presets visible instead of passing their synthetic paths to an external converter', () => {
+    const onChange = renderInput({
+      isDateLikeField: true,
+      converters: {
+        resolveValueFromPath: (item) => `{{${item?.paths?.join('.')}}}`,
+      },
+    });
+    const initial = mocks.variableInputProps?.converters?.resolveValueFromPath?.({
+      name: 'today',
+      title: 'Today',
+      type: 'date',
+      paths: ['date', 'today'],
+    });
+
+    expect(initial).toMatchObject({ kind: 'preset', preset: 'today' });
+    mocks.variableInputProps?.onChange?.(initial);
+    expect(parseCtxDateExpressionConfig(onChange.mock.calls[0]?.[0])).toEqual({
+      kind: 'preset',
+      preset: 'today',
+    });
+    expect(
+      mocks.variableInputProps?.converters?.resolveValueFromPath?.({
+        name: 'title',
+        title: 'Title',
+        type: 'string',
+        paths: ['$jobsMapByNodeKey', 'node1', 'title'],
+      }),
+    ).toBe('{{$jobsMapByNodeKey.node1.title}}');
   });
 
   it('preserves spaces while editing a custom Format', () => {


### PR DESCRIPTION
## Problem

Selecting a built-in date value such as **Date → Today** in workflow create/update node field assignments makes the value component disappear. The workflow converter serializes the synthetic `date.today` path before the field-value converter can create its date configuration.

## Fix

- Let synthetic field-value nodes (`constant`, `null`, `date`, and `runjs`) resolve their own value shapes first.
- Fall back to the domain converter only for nodes from the base variable tree.
- Add a regression test covering **Date → Today** while verifying workflow variables still use the external converter.

## Tests

- `yarn test packages/core/client-v2/src/flow/components/field-value-variable/__tests__/FieldValueVariableInput.test.tsx --run --reporter=verbose`
- `yarn test packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/collection/__tests__/AssignedFieldsEditor.test.tsx --run --reporter=verbose`
- `yarn test packages/plugins/@nocobase/plugin-workflow/src/client-v2/canvas/__tests__/workflowVariableConverters.test.ts --run --reporter=verbose`
- ESLint on touched files
- `git diff --check`