### PR TITLE
fix(plugin-workflow-notification): avoid blocking channel form rendering

### DIFF
--- a/packages/plugins/@nocobase/plugin-notification-email/src/client-v2/__tests__/MessageConfigForm.test.tsx
+++ b/packages/plugins/@nocobase/plugin-notification-email/src/client-v2/__tests__/MessageConfigForm.test.tsx
@@ -1,0 +1,95 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import type { MetaTreeNode } from '@nocobase/flow-engine';
+import { render } from '@testing-library/react';
+import { Form } from 'antd';
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const holder = vi.hoisted(() => ({
+  inputs: [] as Array<{ metaTree?: MetaTreeNode[] }>,
+  textAreas: [] as Array<{ metaTree?: MetaTreeNode[] }>,
+  stringMetaTree: [
+    { name: '$context', title: 'String variables', type: 'object', paths: ['$context'], children: [] },
+  ] as MetaTreeNode[],
+  useWorkflowVariableOptions: vi.fn(),
+}));
+
+vi.mock('@dnd-kit/core', () => ({
+  closestCenter: vi.fn(),
+  DndContext: ({ children }: React.PropsWithChildren) => children,
+  PointerSensor: vi.fn(),
+  useSensor: vi.fn(() => ({})),
+  useSensors: vi.fn(() => []),
+}));
+
+vi.mock('@dnd-kit/sortable', () => ({
+  SortableContext: ({ children }: React.PropsWithChildren) => children,
+  useSortable: () => ({
+    attributes: {},
+    isDragging: false,
+    listeners: {},
+    setActivatorNodeRef: vi.fn(),
+    setNodeRef: vi.fn(),
+    transform: null,
+    transition: undefined,
+  }),
+  verticalListSortingStrategy: {},
+}));
+
+vi.mock('@nocobase/plugin-workflow/client-v2', () => ({
+  useWorkflowVariableOptions: holder.useWorkflowVariableOptions,
+  WorkflowVariableInput: (props: { metaTree?: MetaTreeNode[] }) => {
+    holder.inputs.push(props);
+    return <input />;
+  },
+  WorkflowVariableTextArea: (props: { metaTree?: MetaTreeNode[] }) => {
+    holder.textAreas.push(props);
+    return <textarea />;
+  },
+}));
+
+vi.mock('../locale', () => ({
+  useNotificationEmailTranslation: () => ({ t: (key: string) => key }),
+}));
+
+import { MessageConfigForm } from '../forms/MessageConfigForm';
+
+const META_TREE: MetaTreeNode[] = [
+  { name: '$context', title: 'Trigger variables', type: 'object', paths: ['$context'], children: [] },
+];
+
+describe('email MessageConfigForm (v2)', () => {
+  beforeEach(() => {
+    holder.inputs.length = 0;
+    holder.textAreas.length = 0;
+    holder.useWorkflowVariableOptions.mockReset().mockReturnValue(holder.stringMetaTree);
+  });
+
+  it('computes string variables once and reuses each variable tree across its matching fields', () => {
+    render(
+      <Form initialValues={{ config: { to: [''], cc: [''], bcc: [''] } }}>
+        <MessageConfigForm namePrefix={['config']} variableOptions={META_TREE} />
+      </Form>,
+    );
+
+    expect(holder.inputs.length).toBeGreaterThanOrEqual(4);
+    expect(holder.textAreas.length).toBeGreaterThanOrEqual(2);
+    for (const props of holder.inputs) {
+      expect([META_TREE, holder.stringMetaTree]).toContain(props.metaTree);
+    }
+    expect(holder.inputs.some((props) => props.metaTree === holder.stringMetaTree)).toBe(true);
+    for (const props of holder.textAreas) {
+      expect(props.metaTree).toBe(META_TREE);
+    }
+    expect(holder.useWorkflowVariableOptions).toHaveBeenCalledTimes(1);
+    expect(holder.useWorkflowVariableOptions).toHaveBeenCalledWith({ types: ['string'] });
+  });
+});

--- a/packages/plugins/@nocobase/plugin-notification-email/src/client-v2/forms/MessageConfigForm.tsx
+++ b/packages/plugins/@nocobase/plugin-notification-email/src/client-v2/forms/MessageConfigForm.tsx
@@ -9,7 +9,12 @@
 
 import { DeleteOutlined, MenuOutlined, PlusOutlined } from '@ant-design/icons';
 import type { MessageConfigFormProps } from '@nocobase/plugin-notification-manager/client-v2';
-import { WorkflowVariableInput, WorkflowVariableTextArea } from '@nocobase/plugin-workflow/client-v2';
+import {
+  useWorkflowVariableOptions,
+  WorkflowVariableInput,
+  WorkflowVariableTextArea,
+} from '@nocobase/plugin-workflow/client-v2';
+import type { MetaTreeNode } from '@nocobase/flow-engine';
 import { DndContext, closestCenter, PointerSensor, useSensor, useSensors, type DragEndEvent } from '@dnd-kit/core';
 import type { DraggableAttributes, DraggableSyntheticListeners } from '@dnd-kit/core';
 import { SortableContext, useSortable, verticalListSortingStrategy } from '@dnd-kit/sortable';
@@ -28,6 +33,7 @@ type AddressListProps = {
   placeholder: string;
   requiredMessage: string;
   required?: boolean;
+  variableOptions?: MetaTreeNode[];
 };
 
 type SortableAddressRowContextValue = {
@@ -81,7 +87,7 @@ function AddressSortHandle() {
 }
 
 function AddressList(props: AddressListProps) {
-  const { formPath, title, addLabel, placeholder, required, requiredMessage } = props;
+  const { formPath, title, addLabel, placeholder, required, requiredMessage, variableOptions } = props;
   const sensors = useSensors(
     useSensor(PointerSensor, {
       activationConstraint: {
@@ -140,7 +146,7 @@ function AddressList(props: AddressListProps) {
                       <Flex gap="small" align="center">
                         <AddressSortHandle />
                         <Form.Item name={field.name} noStyle>
-                          <WorkflowVariableInput placeholder={placeholder} variableOptions={{ types: ['string'] }} />
+                          <WorkflowVariableInput metaTree={variableOptions} placeholder={placeholder} />
                         </Form.Item>
                         <Button
                           type="text"
@@ -164,7 +170,11 @@ function AddressList(props: AddressListProps) {
   );
 }
 
-export function MessageConfigForm(props: MessageConfigFormProps) {
+type MessageConfigFormContentProps = MessageConfigFormProps & {
+  stringVariableOptions: MetaTreeNode[];
+};
+
+function MessageConfigFormContent(props: MessageConfigFormContentProps) {
   const { t } = useNotificationEmailTranslation();
   const contentType = Form.useWatch(withPrefix(props.namePrefix, 'contentType')) ?? 'html';
 
@@ -177,6 +187,7 @@ export function MessageConfigForm(props: MessageConfigFormProps) {
         placeholder={t('Email address')}
         requiredMessage={t('The field value is required')}
         required
+        variableOptions={props.stringVariableOptions}
       />
       <AddressList
         formPath={withPrefix(props.namePrefix, 'cc')}
@@ -184,6 +195,7 @@ export function MessageConfigForm(props: MessageConfigFormProps) {
         addLabel={t('Add email address')}
         placeholder={t('Email address')}
         requiredMessage={t('The field value is required')}
+        variableOptions={props.stringVariableOptions}
       />
       <AddressList
         formPath={withPrefix(props.namePrefix, 'bcc')}
@@ -191,13 +203,14 @@ export function MessageConfigForm(props: MessageConfigFormProps) {
         addLabel={t('Add email address')}
         placeholder={t('Email address')}
         requiredMessage={t('The field value is required')}
+        variableOptions={props.stringVariableOptions}
       />
       <Form.Item
         name={withPrefix(props.namePrefix, 'subject')}
         label={t('Subject')}
         rules={[{ required: true, message: t('The field value is required') }]}
       >
-        <WorkflowVariableInput />
+        <WorkflowVariableInput metaTree={props.variableOptions} />
       </Form.Item>
       <Form.Item name={withPrefix(props.namePrefix, 'contentType')} label={t('Content type')} initialValue="html">
         <Radio.Group
@@ -213,7 +226,7 @@ export function MessageConfigForm(props: MessageConfigFormProps) {
         hidden={contentType !== 'html'}
         rules={contentType === 'html' ? [{ required: true, message: t('The field value is required') }] : undefined}
       >
-        <WorkflowVariableTextArea autoSize={{ minRows: 10 }} placeholder="Hi," />
+        <WorkflowVariableTextArea metaTree={props.variableOptions} autoSize={{ minRows: 10 }} placeholder="Hi," />
       </Form.Item>
       <Form.Item
         name={withPrefix(props.namePrefix, 'text')}
@@ -221,10 +234,16 @@ export function MessageConfigForm(props: MessageConfigFormProps) {
         hidden={contentType !== 'text'}
         rules={contentType === 'text' ? [{ required: true, message: t('The field value is required') }] : undefined}
       >
-        <WorkflowVariableTextArea autoSize={{ minRows: 10 }} placeholder="Hi," />
+        <WorkflowVariableTextArea metaTree={props.variableOptions} autoSize={{ minRows: 10 }} placeholder="Hi," />
       </Form.Item>
     </>
   );
+}
+
+export function MessageConfigForm(props: MessageConfigFormProps) {
+  const stringVariableOptions = useWorkflowVariableOptions({ types: ['string'] });
+
+  return <MessageConfigFormContent {...props} stringVariableOptions={stringVariableOptions} />;
 }
 
 export default MessageConfigForm;

--- a/packages/plugins/@nocobase/plugin-notification-in-app-message/src/client-v2/__tests__/MessageConfigForm.test.tsx
+++ b/packages/plugins/@nocobase/plugin-notification-in-app-message/src/client-v2/__tests__/MessageConfigForm.test.tsx
@@ -1,0 +1,116 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import type { MetaTreeNode } from '@nocobase/flow-engine';
+import { render } from '@testing-library/react';
+import { Form } from 'antd';
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const holder = vi.hoisted(() => ({
+  inputs: [] as Array<{ metaTree?: MetaTreeNode[] }>,
+  textAreas: [] as Array<{ metaTree?: MetaTreeNode[] }>,
+  userSelects: [] as Array<{ variableOptions?: MetaTreeNode[] }>,
+  stringMetaTree: [
+    { name: '$context', title: 'String variables', type: 'object', paths: ['$context'], children: [] },
+  ] as MetaTreeNode[],
+  userMetaTree: [
+    { name: '$context', title: 'User variables', type: 'object', paths: ['$context'], children: [] },
+  ] as MetaTreeNode[],
+  useWorkflowVariableOptions: vi.fn(),
+}));
+
+vi.mock('@dnd-kit/core', () => ({
+  closestCenter: vi.fn(),
+  DndContext: ({ children }: React.PropsWithChildren) => children,
+  PointerSensor: vi.fn(),
+  useSensor: vi.fn(() => ({})),
+  useSensors: vi.fn(() => []),
+}));
+
+vi.mock('@dnd-kit/sortable', () => ({
+  SortableContext: ({ children }: React.PropsWithChildren) => children,
+  useSortable: () => ({
+    attributes: {},
+    isDragging: false,
+    listeners: {},
+    setActivatorNodeRef: vi.fn(),
+    setNodeRef: vi.fn(),
+    transform: null,
+    transition: undefined,
+  }),
+  verticalListSortingStrategy: {},
+}));
+
+vi.mock('@nocobase/plugin-notification-manager/client-v2', () => ({
+  UserAddition: () => null,
+  UserSelect: (props: { variableOptions?: MetaTreeNode[] }) => {
+    holder.userSelects.push(props);
+    return <input />;
+  },
+}));
+
+vi.mock('@nocobase/plugin-workflow/client-v2', () => ({
+  isUserKeyField: vi.fn(),
+  useWorkflowVariableOptions: holder.useWorkflowVariableOptions,
+  WorkflowVariableInput: (props: { metaTree?: MetaTreeNode[] }) => {
+    holder.inputs.push(props);
+    return <input />;
+  },
+  WorkflowVariableTextArea: (props: { metaTree?: MetaTreeNode[] }) => {
+    holder.textAreas.push(props);
+    return <textarea />;
+  },
+}));
+
+vi.mock('../locale', () => ({
+  useInAppMessageTranslation: () => ({ t: (key: string) => key }),
+  useT: () => (key: string) => key,
+}));
+
+import { MessageConfigForm } from '../components/MessageConfigForm';
+
+const META_TREE: MetaTreeNode[] = [
+  { name: '$context', title: 'Trigger variables', type: 'object', paths: ['$context'], children: [] },
+];
+
+describe('in-app-message MessageConfigForm (v2)', () => {
+  beforeEach(() => {
+    holder.inputs.length = 0;
+    holder.textAreas.length = 0;
+    holder.userSelects.length = 0;
+    holder.useWorkflowVariableOptions
+      .mockReset()
+      .mockImplementation((options: { types?: unknown[] }) =>
+        options.types?.[0] === 'string' ? holder.stringMetaTree : holder.userMetaTree,
+      );
+  });
+
+  it('computes filtered variables once per type and reuses them across matching fields', () => {
+    render(
+      <Form initialValues={{ config: { receivers: [''] } }}>
+        <MessageConfigForm namePrefix={['config']} variableOptions={META_TREE} />
+      </Form>,
+    );
+
+    expect(holder.inputs.length).toBeGreaterThanOrEqual(3);
+    expect(holder.textAreas.length).toBeGreaterThanOrEqual(1);
+    expect(holder.userSelects.length).toBeGreaterThanOrEqual(1);
+    for (const props of holder.inputs) {
+      expect(props.metaTree).toBe(holder.stringMetaTree);
+    }
+    for (const props of holder.textAreas) {
+      expect(props.metaTree).toBe(META_TREE);
+    }
+    for (const props of holder.userSelects) {
+      expect(props.variableOptions).toBe(holder.userMetaTree);
+    }
+    expect(holder.useWorkflowVariableOptions).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/plugins/@nocobase/plugin-notification-in-app-message/src/client-v2/components/MessageConfigForm.tsx
+++ b/packages/plugins/@nocobase/plugin-notification-in-app-message/src/client-v2/components/MessageConfigForm.tsx
@@ -10,7 +10,13 @@
 import { DeleteOutlined, MenuOutlined } from '@ant-design/icons';
 import type { MessageConfigFormProps } from '@nocobase/plugin-notification-manager/client-v2';
 import { UserAddition, UserSelect } from '@nocobase/plugin-notification-manager/client-v2';
-import { WorkflowVariableInput, WorkflowVariableTextArea } from '@nocobase/plugin-workflow/client-v2';
+import {
+  isUserKeyField,
+  useWorkflowVariableOptions,
+  WorkflowVariableInput,
+  WorkflowVariableTextArea,
+} from '@nocobase/plugin-workflow/client-v2';
+import type { MetaTreeNode } from '@nocobase/flow-engine';
 import { DndContext, closestCenter, PointerSensor, useSensor, useSensors, type DragEndEvent } from '@dnd-kit/core';
 import type { DraggableAttributes, DraggableSyntheticListeners } from '@dnd-kit/core';
 import { SortableContext, useSortable, verticalListSortingStrategy } from '@dnd-kit/sortable';
@@ -74,7 +80,12 @@ function ReceiverSortHandle() {
   );
 }
 
-export function MessageConfigForm(props: MessageConfigFormProps) {
+type MessageConfigFormContentProps = MessageConfigFormProps & {
+  stringVariableOptions: MetaTreeNode[];
+  userVariableOptions: MetaTreeNode[];
+};
+
+function MessageConfigFormContent(props: MessageConfigFormContentProps) {
   const { t } = useInAppMessageTranslation();
   const compileT = useT();
   const form = Form.useFormInstance();
@@ -143,7 +154,7 @@ export function MessageConfigForm(props: MessageConfigFormProps) {
                           <ReceiverSortHandle />
                           <div style={{ flex: 1, minWidth: 0 }}>
                             <Form.Item name={field.name} noStyle>
-                              <UserSelect variableOptions={props.variableOptions} />
+                              <UserSelect variableOptions={props.userVariableOptions} />
                             </Form.Item>
                           </div>
                           <Button
@@ -168,14 +179,19 @@ export function MessageConfigForm(props: MessageConfigFormProps) {
         label={t('Message title')}
         rules={[{ required: true, message: t('The field value is required') }]}
       >
-        <WorkflowVariableInput variableOptions={{ types: ['string'] }} />
+        <WorkflowVariableInput metaTree={props.stringVariableOptions} />
       </Form.Item>
       <Form.Item
         name={withPrefix(props.namePrefix, 'content')}
         label={t('Message content')}
         rules={[{ required: true, message: t('The field value is required') }]}
       >
-        <WorkflowVariableTextArea autoSize={{ minRows: 10 }} placeholder="Hi," delimiters={['{{{', '}}}']} />
+        <WorkflowVariableTextArea
+          autoSize={{ minRows: 10 }}
+          metaTree={props.variableOptions}
+          placeholder="Hi,"
+          delimiters={['{{{', '}}}']}
+        />
       </Form.Item>
       <Form.Item
         name={withPrefix(props.namePrefix, 'options', 'url')}
@@ -184,7 +200,7 @@ export function MessageConfigForm(props: MessageConfigFormProps) {
           'Support two types of links: internal links and external links. If using an internal link, the link starts with "/", for example, "/admin". If using an external link, the link starts with "http", for example, "https://example.com".',
         )}
       >
-        <WorkflowVariableInput variableOptions={{ types: ['string'] }} />
+        <WorkflowVariableInput metaTree={props.stringVariableOptions} />
       </Form.Item>
       <Form.Item
         name={withPrefix(props.namePrefix, 'options', 'mobileUrl')}
@@ -193,7 +209,7 @@ export function MessageConfigForm(props: MessageConfigFormProps) {
           'Support two types of links: internal links and external links. If using an internal link, the link starts with "/", for example, "/m". If using an external link, the link starts with "http", for example, "https://example.com".',
         )}
       >
-        <WorkflowVariableInput variableOptions={{ types: ['string'] }} />
+        <WorkflowVariableInput metaTree={props.stringVariableOptions} />
       </Form.Item>
       <Form.Item
         name={withPrefix(props.namePrefix, 'options', 'duration')}
@@ -204,6 +220,19 @@ export function MessageConfigForm(props: MessageConfigFormProps) {
         <InputNumber />
       </Form.Item>
     </>
+  );
+}
+
+export function MessageConfigForm(props: MessageConfigFormProps) {
+  const stringVariableOptions = useWorkflowVariableOptions({ types: ['string'] });
+  const userVariableOptions = useWorkflowVariableOptions({ types: [isUserKeyField] });
+
+  return (
+    <MessageConfigFormContent
+      {...props}
+      stringVariableOptions={stringVariableOptions}
+      userVariableOptions={userVariableOptions}
+    />
   );
 }
 

--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/canvas/WorkflowVariableInput.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/canvas/WorkflowVariableInput.tsx
@@ -50,11 +50,12 @@ export type WorkflowVariableInputProps = {
   metaTree?: MetaTreeNode[];
 };
 
-export function WorkflowVariableInput(props: WorkflowVariableInputProps) {
-  const { variableOptions, disabled, metaTree: metaTreeProp, ...rest } = props;
+function WorkflowVariableInputWithMetaTree({
+  disabled,
+  metaTree,
+  ...rest
+}: Omit<WorkflowVariableInputProps, 'metaTree' | 'variableOptions'> & { metaTree: MetaTreeNode[] }) {
   const { componentDisabled } = ConfigProvider.useConfig();
-  const canvasMetaTree = useWorkflowVariableOptions(variableOptions);
-  const metaTree = metaTreeProp ?? canvasMetaTree;
   const tree = useMemo(() => metaTree, [metaTree]);
   return (
     <VariableHybridInput
@@ -64,4 +65,16 @@ export function WorkflowVariableInput(props: WorkflowVariableInputProps) {
       converters={workflowVariableConverters}
     />
   );
+}
+
+function CanvasWorkflowVariableInput({ variableOptions, ...props }: WorkflowVariableInputProps) {
+  const metaTree = useWorkflowVariableOptions(variableOptions);
+  return <WorkflowVariableInputWithMetaTree {...props} metaTree={metaTree} />;
+}
+
+export function WorkflowVariableInput({ metaTree, variableOptions, ...props }: WorkflowVariableInputProps) {
+  if (metaTree !== undefined) {
+    return <WorkflowVariableInputWithMetaTree {...props} metaTree={metaTree} />;
+  }
+  return <CanvasWorkflowVariableInput {...props} variableOptions={variableOptions} />;
 }

--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/canvas/WorkflowVariableTextArea.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/canvas/WorkflowVariableTextArea.tsx
@@ -41,21 +41,12 @@ const codeTextAreaClassName = css`
   font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
 `;
 
-export function WorkflowVariableTextArea(props: WorkflowVariableTextAreaProps) {
-  const {
-    value = '',
-    onChange,
-    variableOptions,
-    metaTree: metaTreeProp,
-    className,
-    style,
-    delimiters = ['{{', '}}'],
-    ...rest
-  } = props;
+function WorkflowVariableTextAreaWithMetaTree(
+  props: Omit<WorkflowVariableTextAreaProps, 'metaTree' | 'variableOptions'> & { metaTree: MetaTreeNode[] },
+) {
+  const { value = '', onChange, metaTree, className, style, delimiters = ['{{', '}}'], ...rest } = props;
   const [innerValue, setInnerValue] = useState(value);
   const inputRef = useRef<TextAreaRef>(null);
-  const canvasMetaTree = useWorkflowVariableOptions(variableOptions);
-  const metaTree = metaTreeProp ?? canvasMetaTree;
   const metaTreeGetter = useMemo(() => () => metaTree, [metaTree]);
 
   useEffect(() => {
@@ -135,4 +126,16 @@ export function WorkflowVariableTextArea(props: WorkflowVariableTextAreaProps) {
       </div>
     </div>
   );
+}
+
+function CanvasWorkflowVariableTextArea({ variableOptions, ...props }: WorkflowVariableTextAreaProps) {
+  const metaTree = useWorkflowVariableOptions(variableOptions);
+  return <WorkflowVariableTextAreaWithMetaTree {...props} metaTree={metaTree} />;
+}
+
+export function WorkflowVariableTextArea({ metaTree, variableOptions, ...props }: WorkflowVariableTextAreaProps) {
+  if (metaTree !== undefined) {
+    return <WorkflowVariableTextAreaWithMetaTree {...props} metaTree={metaTree} />;
+  }
+  return <CanvasWorkflowVariableTextArea {...props} variableOptions={variableOptions} />;
 }

--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/canvas/__tests__/WorkflowVariableFields.test.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/canvas/__tests__/WorkflowVariableFields.test.tsx
@@ -1,0 +1,59 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import type { MetaTreeNode } from '@nocobase/flow-engine';
+import { render } from '@testing-library/react';
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const holder = vi.hoisted(() => ({
+  input: vi.fn(() => null),
+  selector: vi.fn(({ children }) => children),
+  useWorkflowVariableOptions: vi.fn(() => []),
+}));
+
+vi.mock('@nocobase/flow-engine', async (importOriginal) => ({
+  ...((await importOriginal()) as object),
+  FlowContextSelector: holder.selector,
+  VariableHybridInput: holder.input,
+}));
+
+vi.mock('../useWorkflowVariableOptions', () => ({
+  useWorkflowVariableOptions: holder.useWorkflowVariableOptions,
+}));
+
+import { WorkflowVariableInput } from '../WorkflowVariableInput';
+import { WorkflowVariableTextArea } from '../WorkflowVariableTextArea';
+
+const META_TREE: MetaTreeNode[] = [
+  { name: '$context', title: 'Trigger variables', type: 'object', paths: ['$context'], children: [] },
+];
+
+describe('workflow variable fields', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('does not rebuild workflow variables when WorkflowVariableInput receives a meta tree', () => {
+    render(<WorkflowVariableInput metaTree={META_TREE} />);
+
+    expect(holder.useWorkflowVariableOptions).not.toHaveBeenCalled();
+    expect(holder.input).toHaveBeenCalledWith(expect.objectContaining({ metaTree: META_TREE }), expect.anything());
+  });
+
+  it('does not rebuild workflow variables when WorkflowVariableTextArea receives a meta tree', () => {
+    render(<WorkflowVariableTextArea metaTree={META_TREE} />);
+
+    expect(holder.useWorkflowVariableOptions).not.toHaveBeenCalled();
+    expect(holder.selector).toHaveBeenCalledWith(
+      expect.objectContaining({ metaTree: expect.any(Function) }),
+      expect.anything(),
+    );
+  });
+});

--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/UsersSelect.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/UsersSelect.tsx
@@ -161,7 +161,11 @@ function FixedUserSelect(props: {
   );
 }
 
-export function UsersSelect({
+type UsersSelectWithMetaTreeProps = Omit<UsersSelectProps, 'variableOptions'> & {
+  workflowVariableOptions: MetaTreeNode[];
+};
+
+function UsersSelectWithMetaTree({
   disabled,
   dropdownFooter = null,
   includeDateRangeVariable = true,
@@ -170,11 +174,11 @@ export function UsersSelect({
   popupClassName,
   transformVariableOptions,
   value,
-}: UsersSelectProps) {
+  workflowVariableOptions,
+}: UsersSelectWithMetaTreeProps) {
   const ctx = useFlowContext();
   const t = useT();
   const { token } = theme.useToken();
-  const workflowVariableOptions = useWorkflowVariableOptions({ types: [isUserKeyField] });
   const translate = useMemoizedFn((key: string) => ctx?.t?.(key, { ns: 'workflow', nsMode: 'fallback' }) ?? t(key));
   const metaTree = useMemo(() => {
     const roots = transformVariableOptions
@@ -214,6 +218,18 @@ export function UsersSelect({
       value={typeof value === 'string' || typeof value === 'number' ? value : ''}
     />
   );
+}
+
+function CanvasUsersSelect(props: Omit<UsersSelectProps, 'variableOptions'>) {
+  const workflowVariableOptions = useWorkflowVariableOptions({ types: [isUserKeyField] });
+  return <UsersSelectWithMetaTree {...props} workflowVariableOptions={workflowVariableOptions} />;
+}
+
+export function UsersSelect({ variableOptions, ...props }: UsersSelectProps) {
+  if (variableOptions !== undefined) {
+    return <UsersSelectWithMetaTree {...props} workflowVariableOptions={variableOptions} />;
+  }
+  return <CanvasUsersSelect {...props} />;
 }
 
 export default UsersSelect;

--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/__tests__/UsersSelect.test.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/__tests__/UsersSelect.test.tsx
@@ -76,6 +76,22 @@ describe('UsersSelect', () => {
     ]);
   });
 
+  it('uses caller-provided variable options without rebuilding the workflow variable tree', () => {
+    const variableOptions = [
+      { name: '$context', title: 'Trigger variables', type: 'object', paths: ['$context'], children: [] },
+    ];
+
+    render(<UsersSelect variableOptions={variableOptions} />);
+
+    expect(holder.variableOptions).not.toHaveBeenCalled();
+    expect(holder.flowContextSelector).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metaTree: expect.arrayContaining([expect.objectContaining({ name: '$context' })]),
+      }),
+      expect.anything(),
+    );
+  });
+
   it('forwards transformed workflow variables to user queries', () => {
     const transformVariableOptions = vi.fn((options) => options);
 


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [x] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Workflow v2 notification nodes could freeze the frontend for about one minute after selecting an in-app message or email channel. The delay happens on the main thread: every workflow-variable field synchronously rebuilt the same variable tree by traversing upstream nodes and collection fields, even when the notification form had already supplied a precomputed tree. Large workflows multiplied this work across the channel form's inputs.

### Description

- Skip local workflow-variable tree generation in `WorkflowVariableInput`, `WorkflowVariableTextArea`, and `UsersSelect` when a precomputed tree is supplied.
- Build the filtered string/user trees once at each channel form boundary and reuse them across matching email and in-app-message fields.
- Keep the unfiltered tree supplied by the notification node for subject/content fields.
- Add regression coverage for the shared-tree paths and ensure supplied trees do not invoke the expensive builder again.

Testing:

- Email and in-app-message `MessageConfigForm` tests
- Workflow variable input, textarea, and user-select tests
- Notification manager and in-app-message content-form tests
- Email and in-app-message registration tests
- `yarn eslint --fix` on all changed TypeScript files

### Related issues

N/A

### Showcase

N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed frontend freezing after selecting an in-app message or email channel in workflow v2 notification nodes |
| 🇨🇳 Chinese | 修复工作流 v2 通知节点选择站内信或邮箱渠道后前端卡顿的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | 无需更新 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
