### PR TITLE
fix(plugin-block-comment): display commenter nickname

### DIFF
--- a/packages/plugins/@nocobase/plugin-block-comment/src/client-v2/models/__tests__/RecordCommentsBlockView.test.tsx
+++ b/packages/plugins/@nocobase/plugin-block-comment/src/client-v2/models/__tests__/RecordCommentsBlockView.test.tsx
@@ -51,6 +51,119 @@ vi.mock('../components/RecordCommentActions', () => ({
 }));
 
 describe('RecordCommentsBlockView.Item', () => {
+  it('displays the nickname when the commenter field is the last modified by field', async () => {
+    const blockModel = {
+      mapping: {
+        contentField: 'content',
+        commenterField: 'updatedBy',
+      },
+      context: {},
+      resource: {
+        update: vi.fn(),
+      },
+      collection: {
+        filterTargetKey: 'id',
+        fields: [{ name: 'updatedBy', interface: 'updatedBy' }],
+      },
+    } as unknown as RecordCommentsBlockModel;
+
+    render(
+      <App>
+        <RecordCommentsBlockView.Item
+          blockModel={blockModel}
+          itemModel={{ uid: 'item-updated-by' } as FlowModel}
+          record={{
+            id: 1,
+            content: 'Comment content',
+            updatedBy: {
+              title: 'User title field value',
+              nickname: 'User nickname',
+            },
+          }}
+          forkKeyPrefix="comment_item_updated_by"
+        />
+      </App>,
+    );
+
+    expect(screen.getByText('User nickname')).toBeInTheDocument();
+    expect(screen.queryByText('User title field value')).not.toBeInTheDocument();
+  });
+
+  it('falls back to the user title when the last modified by nickname is empty', () => {
+    const blockModel = {
+      mapping: {
+        contentField: 'content',
+        commenterField: 'updatedBy',
+      },
+      context: {},
+      resource: {
+        update: vi.fn(),
+      },
+      collection: {
+        filterTargetKey: 'id',
+        fields: [{ name: 'updatedBy', interface: 'updatedBy' }],
+      },
+    } as unknown as RecordCommentsBlockModel;
+
+    render(
+      <App>
+        <RecordCommentsBlockView.Item
+          blockModel={blockModel}
+          itemModel={{ uid: 'item-updated-by-empty-nickname' } as FlowModel}
+          record={{
+            id: 2,
+            content: 'Comment content',
+            updatedBy: {
+              title: 'Fallback user title',
+              nickname: '',
+            },
+          }}
+          forkKeyPrefix="comment_item_updated_by_empty_nickname"
+        />
+      </App>,
+    );
+
+    expect(screen.getByText('Fallback user title')).toBeInTheDocument();
+  });
+
+  it('keeps the title field priority for custom commenter associations', () => {
+    const blockModel = {
+      mapping: {
+        contentField: 'content',
+        commenterField: 'commenter',
+      },
+      context: {},
+      resource: {
+        update: vi.fn(),
+      },
+      collection: {
+        filterTargetKey: 'id',
+        fields: [{ name: 'commenter', interface: 'm2o' }],
+      },
+    } as unknown as RecordCommentsBlockModel;
+
+    render(
+      <App>
+        <RecordCommentsBlockView.Item
+          blockModel={blockModel}
+          itemModel={{ uid: 'item-custom-commenter' } as FlowModel}
+          record={{
+            id: 3,
+            content: 'Comment content',
+            commenter: {
+              title: 'Custom commenter title',
+              nickname: 'Custom commenter nickname',
+            },
+          }}
+          forkKeyPrefix="comment_item_custom_commenter"
+        />
+      </App>,
+    );
+
+    expect(screen.getByText('Custom commenter title')).toBeInTheDocument();
+    expect(screen.queryByText('Custom commenter nickname')).not.toBeInTheDocument();
+  });
+
   it('restores the original content after canceling an edit', async () => {
     const renderSpy = vi.fn();
     const markdown = {

--- a/packages/plugins/@nocobase/plugin-block-comment/src/client-v2/models/components/RecordCommentsBlockView.tsx
+++ b/packages/plugins/@nocobase/plugin-block-comment/src/client-v2/models/components/RecordCommentsBlockView.tsx
@@ -213,12 +213,22 @@ const getCommenterDisplayName = (
   record: RecordCommentRecord,
   mapping: RecordCommentsBlockModel['mapping'],
   fallback: string,
+  collection: unknown,
 ) => {
   if (!mapping.commenterField) {
     return fallback;
   }
 
-  return getDisplayValue(record[mapping.commenterField]);
+  const commenter = record[mapping.commenterField];
+  const commenterCollectionField = getCollectionField(collection, mapping.commenterField);
+  if (commenterCollectionField?.interface === 'updatedBy' && commenter && typeof commenter === 'object') {
+    const nickname = (commenter as RecordCommentRecord).nickname;
+    if (typeof nickname === 'string' && nickname.trim()) {
+      return nickname;
+    }
+  }
+
+  return getDisplayValue(commenter);
 };
 
 const DisplayContent = observer(({ value, model }: { value: unknown; model: RecordCommentsBlockModel }) => {
@@ -537,7 +547,7 @@ const RecordCommentItemView = observer(
     const [editing, setEditing] = useState(false);
     const [updateValue, setUpdateValue] = useState(contentValue);
     const [saving, setSaving] = useState(false);
-    const title = getCommenterDisplayName(record, mapping, t('Comment'));
+    const title = getCommenterDisplayName(record, mapping, t('Comment'), blockModel.collection);
     const dateValue = mapping.dateField ? record[mapping.dateField] : undefined;
     const recordKey = getRecordPrimaryKeyValue(record, blockModel.collection);
 


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
When the record comments block uses the "Last modified by" field as the commenter field, it displays the users collection title field value instead of the user's nickname.

### Description
Prioritize a non-empty `nickname` when the configured commenter field uses the `updatedBy` interface, while preserving the existing display behavior and fallbacks for other commenter fields. Add regression tests covering nickname display, empty-nickname fallback, and unchanged custom-association behavior.

Testing performed:
- `yarn eslint --fix packages/plugins/@nocobase/plugin-block-comment/src/client-v2/models/utils.ts packages/plugins/@nocobase/plugin-block-comment/src/client-v2/models/__tests__/RecordCommentsBlockView.test.tsx`
- All five client-v2 record comment model test files passed (65 tests total).

### Related issues

N/A

### Showcase

N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed the record comments block to display the commenter's nickname when using the Last modified by field |
| 🇨🇳 Chinese | 修复评论区块使用“最后修改人”字段时应显示评论人昵称的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | 无需更新 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
