### PR TITLE
fix(plugin-ai): atomically finalize aborted tool calls

### DIFF
--- a/packages/plugins/@nocobase/plugin-ai/src/server/__tests__/aborted-ai-message.test.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/__tests__/aborted-ai-message.test.ts
@@ -169,7 +169,9 @@ describe('AIEmployee aborted AI message persistence', () => {
     expect(messages.filter((item) => item.role === 'test-employee')).toHaveLength(1);
     expect(messages.filter((item) => item.role === 'tool')).toHaveLength(3);
     expect((await listToolMessages()).map((item) => item.toolCallId)).toEqual(['call_A', 'call_B', 'call_C']);
-    expect(saved.message.messageId).toBe(messages.find((item) => item.role === 'test-employee')?.messageId);
+    expect(String(saved.message.messageId)).toBe(
+      String(messages.find((item) => item.role === 'test-employee')?.messageId),
+    );
   });
 
   it('serializes concurrent afterModel and abort persistence for the same LangChain message', async () => {

--- a/packages/plugins/@nocobase/plugin-ai/src/server/__tests__/aborted-ai-message.test.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/__tests__/aborted-ai-message.test.ts
@@ -1,0 +1,320 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { AIMessage as LangChainAIMessage } from '@langchain/core/messages';
+import { UniqueConstraintError } from '@nocobase/database';
+import { createMockServer, MockServer } from '@nocobase/test';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createAIChatConversation } from '../manager/ai-chat-conversation';
+import { AIEmployee } from '../ai-employees/ai-employee';
+import { LLMProvider } from '../llm-providers/provider';
+import PluginAIServer from '../plugin';
+
+const sessionId = '76dd71a8-6550-4bb6-8198-ff8e73bc2ff1';
+const interruptedContent = 'The tool call was interrupted because the conversation was aborted.';
+const toolCalls = ['A', 'B', 'C'].map((suffix) => ({
+  id: `call_${suffix}`,
+  name: `tool${suffix}`,
+  args: { suffix },
+  type: 'tool_call' as const,
+}));
+
+const provider = {
+  reshapeAIMessage: vi.fn(),
+} as unknown as LLMProvider;
+
+describe('AIEmployee aborted AI message persistence', () => {
+  let app: MockServer;
+  let employee: AIEmployee;
+
+  beforeAll(async () => {
+    app = await createMockServer({
+      plugins: ['nocobase', 'field-sort', 'workflow'],
+    });
+    await app.pm.enable('ai');
+  });
+
+  beforeEach(async () => {
+    await app.db.getModel('aiToolMessages').destroy({ where: {} });
+    await app.db.getModel('aiMessages').destroy({ where: {} });
+    await app.db.getModel('aiConversations').destroy({ where: {} });
+    await app.db.getRepository('aiConversations').create({
+      values: { sessionId, from: 'main-agent', category: 'chat' },
+    });
+
+    const ctx = {
+      app,
+      db: app.db,
+      logger: app.logger,
+    };
+    employee = Object.create(AIEmployee.prototype) as AIEmployee;
+    Reflect.set(employee, 'ctx', ctx);
+    Reflect.set(employee, 'db', app.db);
+    Reflect.set(employee, 'plugin', app.pm.get('ai') as PluginAIServer);
+    Reflect.set(employee, 'sessionId', sessionId);
+    Reflect.set(employee, 'employee', {
+      username: 'test-employee',
+      skillSettings: {},
+      get: (key: string) => (key === 'username' ? 'test-employee' : undefined),
+    });
+    Reflect.set(employee, 'aiChatConversation', createAIChatConversation(ctx as never, sessionId));
+    vi.spyOn(employee, 'getToolsMap').mockResolvedValue(
+      new Map(
+        toolCalls.map((toolCall) => [
+          toolCall.name,
+          {
+            definition: { name: toolCall.name },
+            defaultPermission: 'ALLOW',
+            scope: 'BUILT_IN',
+            execution: 'backend',
+          },
+        ]),
+      ) as never,
+    );
+  });
+
+  afterAll(async () => {
+    await app.db.clean({ drop: true });
+    await app.destroy();
+  });
+
+  function createMessage(id = 'langchain-message-1', calls = toolCalls) {
+    return new LangChainAIMessage({
+      id,
+      content: 'Calling tools',
+      tool_calls: calls,
+    });
+  }
+
+  async function finalize(message = createMessage(), knownMessageId?: string) {
+    return await employee.finalizeAbortedAIMessage({
+      aiMessage: message,
+      providerName: 'bedrock',
+      provider,
+      llmService: 'bedrock-service',
+      model: 'claude',
+      knownMessageId,
+    });
+  }
+
+  async function listMessages() {
+    return await app.db.getRepository('aiConversations.messages', sessionId).find({ sort: ['messageId'] });
+  }
+
+  async function listToolMessages() {
+    return await app.db.getRepository('aiToolMessages').find({ sort: ['toolCallId'] });
+  }
+
+  it('atomically closes every tool call when an unsaved AI message is aborted', async () => {
+    await finalize();
+
+    const messages = await listMessages();
+    const aiMessages = messages.filter((message) => message.role === 'test-employee');
+    const resultMessages = messages.filter((message) => message.role === 'tool');
+    const toolMessages = await listToolMessages();
+
+    expect(aiMessages).toHaveLength(1);
+    expect(aiMessages[0].metadata).toMatchObject({ id: 'langchain-message-1', interrupted: true });
+    expect(aiMessages[0].toolCalls).toEqual(toolCalls);
+    expect(resultMessages).toHaveLength(3);
+    expect(toolMessages).toHaveLength(3);
+
+    for (const toolCall of toolCalls) {
+      const toolRecord = toolMessages.find((record) => record.toolCallId === toolCall.id);
+      const resultMessage = resultMessages.find((message) => message.metadata.toolCallId === toolCall.id);
+      expect(toolRecord).toMatchObject({
+        messageId: aiMessages[0].messageId,
+        invokeStatus: 'confirmed',
+        status: 'error',
+        content: interruptedContent,
+      });
+      expect(resultMessage).toMatchObject({
+        content: { type: 'text', content: interruptedContent },
+        metadata: {
+          messageId: aiMessages[0].messageId,
+          toolCallId: toolCall.id,
+          toolCall,
+          autoCall: true,
+          provider: 'bedrock',
+          model: 'claude',
+          llmService: 'bedrock-service',
+        },
+      });
+    }
+  });
+
+  it('reuses a committed afterModel message even before its stream event is consumed', async () => {
+    const message = createMessage();
+    const values = {
+      role: 'test-employee',
+      content: { type: 'text', content: 'Calling tools' },
+      metadata: { id: message.id, model: 'claude', provider: 'bedrock' },
+      toolCalls,
+    };
+    const saved = await employee.persistAIMessage({
+      values,
+      langChainMessageId: message.id,
+      toolCalls,
+    });
+
+    await finalize(message);
+
+    const messages = await listMessages();
+    expect(messages.filter((item) => item.role === 'test-employee')).toHaveLength(1);
+    expect(messages.filter((item) => item.role === 'tool')).toHaveLength(3);
+    expect((await listToolMessages()).map((item) => item.toolCallId)).toEqual(['call_A', 'call_B', 'call_C']);
+    expect(saved.message.messageId).toBe(messages.find((item) => item.role === 'test-employee')?.messageId);
+  });
+
+  it('serializes concurrent afterModel and abort persistence for the same LangChain message', async () => {
+    const message = createMessage('concurrent-message');
+    const values = {
+      role: 'test-employee',
+      content: { type: 'text', content: 'Calling tools' },
+      metadata: { id: message.id, model: 'claude', provider: 'bedrock' },
+      toolCalls,
+    };
+
+    await Promise.all([
+      employee.persistAIMessage({ values, langChainMessageId: message.id, toolCalls }),
+      finalize(message),
+    ]);
+
+    const messages = await listMessages();
+    expect(messages.filter((item) => item.role === 'test-employee')).toHaveLength(1);
+    expect(messages.filter((item) => item.role === 'tool')).toHaveLength(3);
+    expect(await listToolMessages()).toHaveLength(3);
+  });
+
+  it('retries after a tool-call unique conflict and reuses the winning transaction', async () => {
+    const conversation = Reflect.get(employee, 'aiChatConversation');
+    const originalWithTransaction = conversation.withTransaction.bind(conversation);
+    const uniqueError = Object.create(UniqueConstraintError.prototype) as UniqueConstraintError;
+    const withTransaction = vi
+      .spyOn(conversation, 'withTransaction')
+      .mockRejectedValueOnce(uniqueError)
+      .mockImplementation(originalWithTransaction);
+
+    await finalize(createMessage('unique-retry-message'));
+
+    expect(withTransaction).toHaveBeenCalledTimes(2);
+    expect((await listMessages()).filter((item) => item.role === 'test-employee')).toHaveLength(1);
+    expect(await listToolMessages()).toHaveLength(3);
+    withTransaction.mockRestore();
+  });
+
+  it('does not duplicate already confirmed tool results', async () => {
+    const message = createMessage();
+    const first = await finalize(message);
+
+    await finalize(message, first?.message.messageId);
+
+    const messages = await listMessages();
+    const persistedAIMessage = messages.find((item) => item.role === 'test-employee');
+    expect(messages.filter((item) => item.role === 'test-employee')).toHaveLength(1);
+    expect(messages.filter((item) => item.role === 'tool')).toHaveLength(3);
+    expect(persistedAIMessage?.metadata.interrupted).toBe(true);
+    expect(await listToolMessages()).toHaveLength(3);
+  });
+
+  it('preserves completed afterModel results when abort arrives later', async () => {
+    const message = createMessage('completed-message');
+    const saved = await employee.persistAIMessage({
+      values: {
+        role: 'test-employee',
+        content: { type: 'text', content: 'Calling tools' },
+        metadata: { id: message.id, model: 'claude', provider: 'bedrock' },
+        toolCalls,
+      },
+      langChainMessageId: message.id,
+      toolCalls,
+    });
+    await app.db
+      .getModel('aiToolMessages')
+      .update(
+        { invokeStatus: 'confirmed', status: 'success', content: 'completed' },
+        { where: { messageId: saved.message.messageId } },
+      );
+    await createAIChatConversation(Reflect.get(employee, 'ctx'), sessionId).addMessages(
+      toolCalls.map((toolCall) => ({
+        role: 'tool',
+        content: { type: 'text', content: 'completed' },
+        metadata: {
+          model: 'claude',
+          provider: 'bedrock',
+          messageId: saved.message.messageId,
+          toolCallId: toolCall.id,
+        },
+      })),
+    );
+
+    await finalize(message, saved.message.messageId);
+
+    const messages = await listMessages();
+    const persistedAIMessage = messages.find((item) => item.role === 'test-employee');
+    expect(messages.filter((item) => item.role === 'test-employee')).toHaveLength(1);
+    expect(messages.filter((item) => item.role === 'tool')).toHaveLength(3);
+    expect(persistedAIMessage?.metadata.interrupted).toBeUndefined();
+    expect(await listToolMessages()).toEqual([
+      expect.objectContaining({ invokeStatus: 'confirmed', status: 'success', content: 'completed' }),
+      expect.objectContaining({ invokeStatus: 'confirmed', status: 'success', content: 'completed' }),
+      expect.objectContaining({ invokeStatus: 'confirmed', status: 'success', content: 'completed' }),
+    ]);
+  });
+
+  it('persists an interrupted text-only message without tool records', async () => {
+    await finalize(createMessage('text-only-message', []));
+
+    const messages = await listMessages();
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toMatchObject({
+      role: 'test-employee',
+      metadata: { id: 'text-only-message', interrupted: true },
+      toolCalls: null,
+    });
+    expect(await listToolMessages()).toHaveLength(0);
+  });
+
+  it('rolls back the AI message when tool initialization fails', async () => {
+    vi.spyOn(employee, 'initToolCall').mockRejectedValueOnce(new Error('init failed'));
+
+    await expect(finalize()).rejects.toThrow('init failed');
+    expect(await listMessages()).toHaveLength(0);
+    expect(await listToolMessages()).toHaveLength(0);
+  });
+
+  it('rolls back the AI message and tool records when ToolMessage creation fails', async () => {
+    const conversation = Reflect.get(employee, 'aiChatConversation');
+    const prototype = Object.getPrototypeOf(conversation);
+    const originalAddMessages = prototype.addMessages;
+    const addMessages = vi.spyOn(prototype, 'addMessages');
+    addMessages.mockImplementation(async function (messages) {
+      const list = Array.isArray(messages) ? messages : [messages];
+      if (list.some((message) => message.role === 'tool')) {
+        throw new Error('tool result create failed');
+      }
+      return await originalAddMessages.call(this, messages);
+    });
+
+    await expect(finalize()).rejects.toThrow('tool result create failed');
+    expect(await listMessages()).toHaveLength(0);
+    expect(await listToolMessages()).toHaveLength(0);
+    addMessages.mockRestore();
+  });
+
+  it('rolls back all messages and tool records when the status update fails', async () => {
+    const toolModel = app.db.getModel('aiToolMessages');
+    const update = vi.spyOn(toolModel, 'update').mockRejectedValueOnce(new Error('status update failed'));
+
+    await expect(finalize()).rejects.toThrow('status update failed');
+    expect(await listMessages()).toHaveLength(0);
+    expect(await listToolMessages()).toHaveLength(0);
+    update.mockRestore();
+  });
+});

--- a/packages/plugins/@nocobase/plugin-ai/src/server/__tests__/aborted-ai-message.test.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/__tests__/aborted-ai-message.test.ts
@@ -128,6 +128,7 @@ describe('AIEmployee aborted AI message persistence', () => {
     for (const toolCall of toolCalls) {
       const toolRecord = toolMessages.find((record) => record.toolCallId === toolCall.id);
       const resultMessage = resultMessages.find((message) => message.metadata.toolCallId === toolCall.id);
+      expect(String(resultMessage?.metadata.messageId)).toBe(String(aiMessages[0].messageId));
       expect(toolRecord).toMatchObject({
         messageId: aiMessages[0].messageId,
         invokeStatus: 'confirmed',
@@ -137,7 +138,6 @@ describe('AIEmployee aborted AI message persistence', () => {
       expect(resultMessage).toMatchObject({
         content: { type: 'text', content: interruptedContent },
         metadata: {
-          messageId: aiMessages[0].messageId,
           toolCallId: toolCall.id,
           toolCall,
           autoCall: true,

--- a/packages/plugins/@nocobase/plugin-ai/src/server/__tests__/tool-result-integrity-middleware.test.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/__tests__/tool-result-integrity-middleware.test.ts
@@ -1,0 +1,452 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { AIMessage, BaseMessage, HumanMessage, SystemMessage, ToolMessage } from '@langchain/core/messages';
+import { convertMessagesToCompletionsMessageParams } from '@langchain/openai';
+import { ChatPromptValue } from '@langchain/core/prompt_values';
+import { convertPromptToAnthropic } from '@langchain/anthropic';
+import { FakeListChatModel } from '@langchain/core/utils/testing';
+import { MemorySaver } from '@langchain/langgraph';
+import { createAgent, createMiddleware } from 'langchain';
+import { convertMessagesToResponsesInput } from '@langchain/openai';
+import { describe, expect, it, vi } from 'vitest';
+import { AIEmployee } from '../ai-employees/ai-employee';
+import {
+  isToolCallHistoryValid,
+  normalizeToolCallHistory,
+  toolCallSanitizerMiddleware,
+  toolResultIntegrityMiddleware,
+} from '../ai-employees/middleware';
+import type { AIToolMessage } from '../types/ai-message.type';
+
+type ModelRequest = { messages: BaseMessage[] };
+type ModelHandler = (request: ModelRequest) => unknown;
+type WrapModelCall = (request: ModelRequest, handler: ModelHandler) => unknown;
+
+const getWrapModelCall = (middleware: ReturnType<typeof toolResultIntegrityMiddleware>): WrapModelCall => {
+  const wrapModelCall = (middleware as unknown as { wrapModelCall?: unknown }).wrapModelCall;
+  if (typeof wrapModelCall === 'function') {
+    return wrapModelCall as WrapModelCall;
+  }
+  if (wrapModelCall && typeof wrapModelCall === 'object' && 'hook' in wrapModelCall) {
+    return (wrapModelCall as { hook: WrapModelCall }).hook;
+  }
+  throw new Error('wrapModelCall is not callable');
+};
+
+const toolCall = (id: string, name = `tool_${id}`) => ({ id, name, args: { secret: id }, type: 'tool_call' as const });
+const rawToolCall = (id: string, name = `tool_${id}`) => ({
+  id,
+  type: 'function' as const,
+  function: { name, arguments: JSON.stringify({ secret: id }) },
+});
+const aiMessage = (id: string, callIds: string[], content = '') =>
+  new AIMessage({
+    id,
+    content,
+    tool_calls: callIds.map((callId) => toolCall(callId)),
+    additional_kwargs: callIds.length
+      ? {
+          tool_calls: callIds.map((callId) => rawToolCall(callId)),
+          __openai_function_call_ids__: Object.fromEntries(callIds.map((callId) => [callId, `output_${callId}`])),
+        }
+      : {},
+  });
+const toolMessage = (id: string, suffix = '') =>
+  new ToolMessage({
+    id: `result_${id}${suffix}`,
+    tool_call_id: id,
+    name: `tool_${id}`,
+    content: `result ${id}${suffix}`,
+    status: 'success',
+    additional_kwargs: { preserved: true },
+    response_metadata: { preserved: true },
+    artifact: { preserved: true },
+  });
+const persistedToolMessage = (id: string, overrides: Partial<AIToolMessage> = {}): AIToolMessage => ({
+  id: `db_${id}`,
+  sessionId: 'session_1',
+  messageId: 'message_1',
+  toolCallId: id,
+  toolName: `tool_${id}`,
+  status: 'success',
+  content: { value: id } as unknown as string,
+  invokeStatus: 'confirmed',
+  invokeStartTime: new Date(),
+  invokeEndTime: new Date(),
+  auto: true,
+  execution: 'backend',
+  ...overrides,
+});
+
+const normalize = async (
+  messages: BaseMessage[],
+  persistedResults = new Map<string, AIToolMessage>(),
+  logger = { warn: vi.fn() },
+) => {
+  const loadToolResults = vi.fn().mockResolvedValue(persistedResults);
+  const normalized = await normalizeToolCallHistory(messages, {
+    sessionId: 'session_1',
+    logger,
+    loadToolResults,
+  });
+  return { normalized, loadToolResults, logger };
+};
+
+const messageShape = (messages: BaseMessage[]) =>
+  messages.map((message) => {
+    if (AIMessage.isInstance(message)) {
+      return `ai:${message.tool_calls.map((call) => call.id).join(',')}`;
+    }
+    if (ToolMessage.isInstance(message)) {
+      return `tool:${message.tool_call_id}`;
+    }
+    return message.getType();
+  });
+
+describe('toolResultIntegrityMiddleware', () => {
+  it('uses a zero-allocation fast path for valid histories', async () => {
+    const humanBefore = new HumanMessage('before');
+    const ai = aiMessage('ai_1', ['A', 'B']);
+    const resultA = toolMessage('A');
+    const resultB = toolMessage('B');
+    const humanAfter = new HumanMessage('after');
+    const originalMessages = [humanBefore, ai, resultA, resultB, humanAfter];
+    const loadToolResults = vi.fn();
+    const logger = { warn: vi.fn() };
+    const middleware = toolResultIntegrityMiddleware({ sessionId: 'session_1', loadToolResults, logger });
+    const request = { messages: originalMessages };
+    const handler = vi.fn((handlerRequest) => handlerRequest.messages);
+
+    expect(isToolCallHistoryValid(originalMessages)).toBe(true);
+    const result = await getWrapModelCall(middleware)(request, handler);
+
+    expect(result).toBe(originalMessages);
+    expect(request.messages).toBe(originalMessages);
+    expect(handler.mock.calls[0][0].messages).toBe(originalMessages);
+    expect(loadToolResults).not.toHaveBeenCalled();
+    expect(logger.warn).not.toHaveBeenCalled();
+    expect(originalMessages[1]).toBe(ai);
+    expect(originalMessages[2]).toBe(resultA);
+  });
+
+  it('restores the real failed session shape before the next human messages', async () => {
+    const messages = [
+      new HumanMessage('start'),
+      aiMessage('ai_1', ['call_00', 'call_01']),
+      new HumanMessage('next'),
+      new HumanMessage('again'),
+    ];
+    const persisted = new Map([
+      ['call_00', persistedToolMessage('call_00', { status: 'error', content: 'aborted' })],
+      ['call_01', persistedToolMessage('call_01', { status: 'error', content: 'aborted' })],
+    ]);
+
+    const { normalized, loadToolResults } = await normalize(messages, persisted);
+
+    expect(messageShape(normalized)).toEqual([
+      'human',
+      'ai:call_00,call_01',
+      'tool:call_00',
+      'tool:call_01',
+      'human',
+      'human',
+    ]);
+    expect(loadToolResults).toHaveBeenCalledWith(['call_00', 'call_01']);
+    expect((normalized[2] as ToolMessage).id).toBe('restored-tool-result:session_1:call_00');
+    expect((normalized[2] as ToolMessage).status).toBe('error');
+  });
+
+  it('moves a misplaced existing result without querying the database and preserves the object', async () => {
+    const existingResult = toolMessage('A');
+    const human = new HumanMessage('next');
+    const { normalized, loadToolResults } = await normalize([aiMessage('ai_1', ['A']), human, existingResult]);
+
+    expect(messageShape(normalized)).toEqual(['ai:A', 'tool:A', 'human']);
+    expect(normalized[1]).toBe(existingResult);
+    expect(normalized[2]).toBe(human);
+    expect(loadToolResults).not.toHaveBeenCalled();
+  });
+
+  it('queries and restores only the missing result in original call order', async () => {
+    const resultA = toolMessage('A');
+    const resultC = toolMessage('C');
+    const { normalized, loadToolResults } = await normalize(
+      [aiMessage('ai_1', ['A', 'B', 'C']), resultA, resultC],
+      new Map([['B', persistedToolMessage('B')]]),
+    );
+
+    expect(messageShape(normalized)).toEqual(['ai:A,B,C', 'tool:A', 'tool:B', 'tool:C']);
+    expect(normalized[1]).toBe(resultA);
+    expect(normalized[3]).toBe(resultC);
+    expect(loadToolResults).toHaveBeenCalledTimes(1);
+    expect(loadToolResults).toHaveBeenCalledWith(['B']);
+  });
+
+  it.each([
+    ['no persisted record', new Map<string, AIToolMessage>()],
+    ['non-terminal persisted record', new Map([['A', persistedToolMessage('A', { invokeStatus: 'pending' })]])],
+  ])('creates a deterministic synthetic error for %s', async (_name, persisted) => {
+    const { normalized } = await normalize([aiMessage('ai_1', ['A'])], persisted);
+    const result = normalized[1] as ToolMessage;
+
+    expect(result.id).toBe('synthetic-tool-result:session_1:A');
+    expect(result.status).toBe('error');
+    expect(JSON.parse(result.content as string)).toEqual({
+      status: 'error',
+      error: 'Tool execution was interrupted before a result was recorded.',
+    });
+  });
+
+  it('degrades a database failure to a synthetic result without logging sensitive message data', async () => {
+    const logger = { warn: vi.fn() };
+    const loadToolResults = vi.fn(async () => {
+      logger.warn('Failed to load persisted tool results before model call', {
+        sessionId: 'session_1',
+        error: new Error('database unavailable'),
+      });
+      return new Map<string, AIToolMessage>();
+    });
+    const middleware = toolResultIntegrityMiddleware({ sessionId: 'session_1', logger, loadToolResults });
+    const messages = [new HumanMessage('private user input'), aiMessage('ai_1', ['A'])];
+    const handler = vi.fn((request) => request.messages);
+
+    const normalized = (await getWrapModelCall(middleware)({ messages }, handler)) as BaseMessage[];
+
+    expect((normalized[2] as ToolMessage).status).toBe('error');
+    expect(handler).toHaveBeenCalledTimes(1);
+    const logs = JSON.stringify(logger.warn.mock.calls);
+    expect(logs).not.toContain('private user input');
+    expect(logs).not.toContain('secret');
+    expect(logs).not.toContain('result A');
+  });
+
+  it('removes duplicate calls and keeps parsed, raw, and provider mappings synchronized', async () => {
+    const firstAI = aiMessage('ai_1', ['A']);
+    const secondAI = aiMessage('ai_2', ['A', 'B']);
+    const { normalized } = await normalize(
+      [firstAI, toolMessage('A'), secondAI],
+      new Map([['B', persistedToolMessage('B')]]),
+    );
+    const retainedSecondAI = normalized[2] as AIMessage;
+
+    expect(messageShape(normalized)).toEqual(['ai:A', 'tool:A', 'ai:B', 'tool:B']);
+    expect(retainedSecondAI.tool_calls.map((call) => call.id)).toEqual(['B']);
+    expect((retainedSecondAI.additional_kwargs.tool_calls as Array<{ id: string }>).map((call) => call.id)).toEqual([
+      'B',
+    ]);
+    expect(retainedSecondAI.additional_kwargs.__openai_function_call_ids__).toEqual({ B: 'output_B' });
+    expect(secondAI.tool_calls.map((call) => call.id)).toEqual(['A', 'B']);
+  });
+
+  it('removes invalid parsed IDs, duplicate raw IDs, and stale provider mappings', async () => {
+    const malformed = new AIMessage({
+      id: 'ai_malformed',
+      content: 'partial text',
+      tool_calls: [toolCall('A'), toolCall('A'), toolCall('')],
+      additional_kwargs: {
+        tool_calls: [rawToolCall('A'), rawToolCall('A'), rawToolCall('stale')],
+        __openai_function_call_ids__: { A: 'output_A', stale: 'output_stale' },
+      },
+    });
+
+    const { normalized, loadToolResults } = await normalize([malformed], new Map([['A', persistedToolMessage('A')]]));
+    const retained = normalized[0] as AIMessage;
+
+    expect(messageShape(normalized)).toEqual(['ai:A', 'tool:A']);
+    expect(retained.tool_calls.map((call) => call.id)).toEqual(['A']);
+    expect((retained.additional_kwargs.tool_calls as Array<{ id: string }>).map((call) => call.id)).toEqual(['A']);
+    expect(retained.additional_kwargs.__openai_function_call_ids__).toEqual({ A: 'output_A' });
+    expect(loadToolResults).toHaveBeenCalledWith(['A']);
+    expect(isToolCallHistoryValid(normalized)).toBe(true);
+  });
+
+  it('deletes an empty duplicate-only AI message but retains duplicate-only text as a normal AI message', async () => {
+    const prefix = [aiMessage('ai_1', ['A']), toolMessage('A')];
+    const empty = await normalize([...prefix, aiMessage('ai_empty', ['A'])]);
+    const text = await normalize([...prefix, aiMessage('ai_text', ['A'], 'interrupted text')]);
+
+    expect(messageShape(empty.normalized)).toEqual(['ai:A', 'tool:A']);
+    expect(messageShape(text.normalized)).toEqual(['ai:A', 'tool:A', 'ai:']);
+    expect((text.normalized[2] as AIMessage).content).toBe('interrupted text');
+    expect((text.normalized[2] as AIMessage).additional_kwargs).toEqual({});
+  });
+
+  it('removes orphan and duplicate results, preserving only the first matching object', async () => {
+    const first = toolMessage('A', '_first');
+    const duplicate = toolMessage('A', '_duplicate');
+    const orphan = toolMessage('orphan');
+    const malformed = toolMessage('');
+    const human = new HumanMessage('hello');
+    const { normalized, logger } = await normalize([
+      human,
+      orphan,
+      malformed,
+      aiMessage('ai_1', ['A']),
+      first,
+      duplicate,
+    ]);
+
+    expect(messageShape(normalized)).toEqual(['human', 'ai:A', 'tool:A']);
+    expect(normalized[2]).toBe(first);
+    expect(normalized).not.toContain(duplicate);
+    expect(normalized).not.toContain(orphan);
+    expect(logger.warn).toHaveBeenCalledWith(
+      'Normalize invalid tool call history before model call',
+      expect.objectContaining({ orphanResultCount: 3 }),
+    );
+  });
+
+  it('sanitizes inconsistent raw calls defensively without creating false results', async () => {
+    const rawOnly = new AIMessage({
+      id: 'raw_only',
+      content: '',
+      additional_kwargs: {
+        tool_calls: [{ ...rawToolCall('A'), function: { name: 'tool_A', arguments: '{bad json' } }],
+        reasoning_content: 'preserve',
+      },
+    });
+    const system = new SystemMessage('system');
+    const { normalized, loadToolResults } = await normalize([rawOnly, system]);
+
+    expect(messageShape(normalized)).toEqual(['ai:', 'system']);
+    expect((normalized[0] as AIMessage).additional_kwargs).toEqual({ reasoning_content: 'preserve' });
+    expect(loadToolResults).not.toHaveBeenCalled();
+    expect(normalized.some(ToolMessage.isInstance)).toBe(false);
+  });
+
+  it('runs after the sanitizer in the real middleware pipeline without inventing raw-only tool results', async () => {
+    let capturedMessages: BaseMessage[] = [];
+    const loadToolResults = vi.fn();
+    const agent = createAgent({
+      model: new FakeListChatModel({ responses: ['done'] }),
+      tools: [],
+      middleware: [
+        toolCallSanitizerMiddleware(),
+        toolResultIntegrityMiddleware({ sessionId: 'session_1', loadToolResults }),
+        createMiddleware({
+          name: 'CaptureMessagesMiddleware',
+          wrapModelCall: (request, handler) => {
+            capturedMessages = request.messages;
+            return handler(request);
+          },
+        }),
+      ],
+      checkpointer: new MemorySaver(),
+    });
+
+    await agent.invoke(
+      {
+        messages: [
+          new AIMessage({
+            id: 'raw_only',
+            content: '',
+            additional_kwargs: {
+              tool_calls: [{ ...rawToolCall('A'), function: { name: 'tool_A', arguments: '{bad json' } }],
+            },
+          }),
+          new HumanMessage('continue'),
+        ],
+      } as never,
+      { configurable: { thread_id: 'sanitizer-integrity-order' } },
+    );
+
+    expect((capturedMessages[0] as AIMessage).tool_calls).toEqual([]);
+    expect((capturedMessages[0] as AIMessage).additional_kwargs).not.toHaveProperty('tool_calls');
+    expect(capturedMessages.some(ToolMessage.isInstance)).toBe(false);
+    expect(loadToolResults).not.toHaveBeenCalled();
+  });
+
+  it('produces a valid OpenAI strict tool-message sequence after normalization', async () => {
+    const { normalized } = await normalize([
+      aiMessage('ai_1', ['A', 'B']),
+      new HumanMessage('must come after outputs'),
+      toolMessage('B'),
+    ]);
+    const providerMessages = convertMessagesToCompletionsMessageParams({ messages: normalized });
+
+    expect(providerMessages.map((message) => message.role)).toEqual(['assistant', 'tool', 'tool', 'user']);
+    expect(providerMessages[1]).toMatchObject({ role: 'tool', tool_call_id: 'A' });
+    expect(providerMessages[2]).toMatchObject({ role: 'tool', tool_call_id: 'B' });
+    expect(isToolCallHistoryValid(normalized)).toBe(true);
+  });
+
+  it('produces strict OpenAI and DeepSeek Responses function call output ordering', async () => {
+    const { normalized } = await normalize([
+      aiMessage('ai_1', ['A', 'B']),
+      new HumanMessage('must come after outputs'),
+    ]);
+    const input = convertMessagesToResponsesInput({
+      model: 'deepseek-v4-flash',
+      zdrEnabled: false,
+      messages: normalized,
+    });
+    const functionItems = input.filter((item) => item.type === 'function_call' || item.type === 'function_call_output');
+
+    expect(functionItems.map((item) => [item.type, 'call_id' in item ? item.call_id : undefined])).toEqual([
+      ['function_call', 'A'],
+      ['function_call', 'B'],
+      ['function_call_output', 'A'],
+      ['function_call_output', 'B'],
+    ]);
+    expect(input.at(-1)).toMatchObject({ type: 'message', role: 'user' });
+  });
+
+  it('produces strict Anthropic and Bedrock-compatible tool use/result ordering', async () => {
+    const { normalized } = await normalize([aiMessage('ai_1', ['A']), new HumanMessage('must come after result')]);
+    const payload = convertPromptToAnthropic(new ChatPromptValue(normalized));
+
+    expect(payload.messages).toEqual([
+      expect.objectContaining({
+        role: 'assistant',
+        content: [expect.objectContaining({ type: 'tool_use', id: 'A' })],
+      }),
+      expect.objectContaining({
+        role: 'user',
+        content: [expect.objectContaining({ type: 'tool_result', tool_use_id: 'A' })],
+      }),
+      expect.objectContaining({ role: 'user', content: 'must come after result' }),
+    ]);
+  });
+
+  it('loads persisted results with session-scoped IDs and terminal-state precedence', async () => {
+    const findAll = vi.fn().mockResolvedValue([
+      { toJSON: () => ({ ...persistedToolMessage('A', { invokeStatus: 'done' }), updatedAt: '2026-01-03' }) },
+      { toJSON: () => ({ ...persistedToolMessage('A', { invokeStatus: 'confirmed' }), updatedAt: '2026-01-01' }) },
+      { toJSON: () => ({ ...persistedToolMessage('B', { invokeStatus: 'pending' }), updatedAt: '2026-01-04' }) },
+      { toJSON: () => ({ ...persistedToolMessage('C', { invokeStatus: 'done' }), updatedAt: '2026-01-01' }) },
+      {
+        toJSON: () => ({
+          ...persistedToolMessage('C', { invokeStatus: 'done', content: 'newer' }),
+          updatedAt: '2026-01-02',
+        }),
+      },
+    ]);
+    const fakeEmployee = { sessionId: 'session_1', aiToolMessagesModel: { findAll } };
+
+    const results = await AIEmployee.prototype.getToolCallResults.call(fakeEmployee as unknown as AIEmployee, [
+      'A',
+      'B',
+      'C',
+    ]);
+
+    expect(findAll).toHaveBeenCalledWith({
+      where: {
+        sessionId: 'session_1',
+        toolCallId: expect.any(Object),
+      },
+    });
+    const where = findAll.mock.calls[0][0].where;
+    expect(Reflect.ownKeys(where.toolCallId)).toHaveLength(1);
+    expect(where.toolCallId[Reflect.ownKeys(where.toolCallId)[0]]).toEqual(['A', 'B', 'C']);
+    expect(results.get('A')?.invokeStatus).toBe('confirmed');
+    expect(results.has('B')).toBe(false);
+    expect(results.get('C')?.content).toBe('newer');
+  });
+});

--- a/packages/plugins/@nocobase/plugin-ai/src/server/__tests__/tool-result-integrity-middleware.test.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/__tests__/tool-result-integrity-middleware.test.ts
@@ -136,6 +136,36 @@ describe('toolResultIntegrityMiddleware', () => {
     expect(originalMessages[2]).toBe(resultA);
   });
 
+  it('uses the fast path when contiguous tool results are complete but out of declaration order', async () => {
+    const ai = aiMessage('ai_1', ['A', 'B']);
+    const resultB = toolMessage('B');
+    const resultA = toolMessage('A');
+    const originalMessages = [ai, resultB, resultA, new HumanMessage('after')];
+    const loadToolResults = vi.fn();
+    const logger = { warn: vi.fn() };
+    const middleware = toolResultIntegrityMiddleware({ sessionId: 'session_1', loadToolResults, logger });
+    const request = { messages: originalMessages };
+    const handler = vi.fn((handlerRequest) => handlerRequest.messages);
+
+    expect(isToolCallHistoryValid(originalMessages)).toBe(true);
+    const result = await getWrapModelCall(middleware)(request, handler);
+
+    expect(result).toBe(originalMessages);
+    expect(request.messages).toBe(originalMessages);
+    expect(handler.mock.calls[0][0].messages).toBe(originalMessages);
+    expect(originalMessages[1]).toBe(resultB);
+    expect(originalMessages[2]).toBe(resultA);
+    expect(loadToolResults).not.toHaveBeenCalled();
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('rejects duplicate or unrelated contiguous tool results even when result order is flexible', () => {
+    const ai = aiMessage('ai_1', ['A', 'B']);
+
+    expect(isToolCallHistoryValid([ai, toolMessage('B'), toolMessage('B')])).toBe(false);
+    expect(isToolCallHistoryValid([ai, toolMessage('B'), toolMessage('C')])).toBe(false);
+  });
+
   it('restores the real failed session shape before the next human messages', async () => {
     const messages = [
       new HumanMessage('start'),

--- a/packages/plugins/@nocobase/plugin-ai/src/server/__tests__/tool-result-integrity-middleware.test.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/__tests__/tool-result-integrity-middleware.test.ts
@@ -204,7 +204,7 @@ describe('toolResultIntegrityMiddleware', () => {
     expect(loadToolResults).not.toHaveBeenCalled();
   });
 
-  it('queries and restores only the missing result in original call order', async () => {
+  it('queries and restores only the missing result while keeping all results contiguous', async () => {
     const resultA = toolMessage('A');
     const resultC = toolMessage('C');
     const { normalized, loadToolResults } = await normalize(
@@ -212,9 +212,14 @@ describe('toolResultIntegrityMiddleware', () => {
       new Map([['B', persistedToolMessage('B')]]),
     );
 
-    expect(messageShape(normalized)).toEqual(['ai:A,B,C', 'tool:A', 'tool:B', 'tool:C']);
-    expect(normalized[1]).toBe(resultA);
-    expect(normalized[3]).toBe(resultC);
+    expect(messageShape(normalized)[0]).toBe('ai:A,B,C');
+    expect(normalized.slice(1)).toHaveLength(3);
+    expect(normalized.slice(1).every(ToolMessage.isInstance)).toBe(true);
+    expect(new Set(normalized.slice(1).map((message) => (message as ToolMessage).tool_call_id))).toEqual(
+      new Set(['A', 'B', 'C']),
+    );
+    expect(normalized).toContain(resultA);
+    expect(normalized).toContain(resultC);
     expect(loadToolResults).toHaveBeenCalledTimes(1);
     expect(loadToolResults).toHaveBeenCalledWith(['B']);
   });
@@ -257,55 +262,36 @@ describe('toolResultIntegrityMiddleware', () => {
     expect(logs).not.toContain('result A');
   });
 
-  it('removes duplicate calls and keeps parsed, raw, and provider mappings synchronized', async () => {
-    const firstAI = aiMessage('ai_1', ['A']);
-    const secondAI = aiMessage('ai_2', ['A', 'B']);
-    const { normalized } = await normalize(
-      [firstAI, toolMessage('A'), secondAI],
-      new Map([['B', persistedToolMessage('B')]]),
-    );
-    const retainedSecondAI = normalized[2] as AIMessage;
-
-    expect(messageShape(normalized)).toEqual(['ai:A', 'tool:A', 'ai:B', 'tool:B']);
-    expect(retainedSecondAI.tool_calls.map((call) => call.id)).toEqual(['B']);
-    expect((retainedSecondAI.additional_kwargs.tool_calls as Array<{ id: string }>).map((call) => call.id)).toEqual([
-      'B',
-    ]);
-    expect(retainedSecondAI.additional_kwargs.__openai_function_call_ids__).toEqual({ B: 'output_B' });
-    expect(secondAI.tool_calls.map((call) => call.id)).toEqual(['A', 'B']);
-  });
-
-  it('removes invalid parsed IDs, duplicate raw IDs, and stale provider mappings', async () => {
-    const malformed = new AIMessage({
-      id: 'ai_malformed',
-      content: 'partial text',
-      tool_calls: [toolCall('A'), toolCall('A'), toolCall('')],
+  it('preserves AI messages unchanged while moving and restoring tool results', async () => {
+    const content = [
+      { type: 'tool_call', id: 'A', name: 'tool_A', args: { secret: 'A' } },
+      { type: 'text', text: 'partial response' },
+    ];
+    const ai = new AIMessage({
+      id: 'ai_1',
+      content,
+      tool_calls: [toolCall('A'), toolCall('B')],
       additional_kwargs: {
-        tool_calls: [rawToolCall('A'), rawToolCall('A'), rawToolCall('stale')],
-        __openai_function_call_ids__: { A: 'output_A', stale: 'output_stale' },
+        tool_calls: [rawToolCall('A'), rawToolCall('B')],
+        __openai_function_call_ids__: { A: 'output_A', B: 'output_B' },
       },
     });
+    const existingResult = toolMessage('A');
+    const human = new HumanMessage('next');
 
-    const { normalized, loadToolResults } = await normalize([malformed], new Map([['A', persistedToolMessage('A')]]));
-    const retained = normalized[0] as AIMessage;
+    const { normalized, loadToolResults } = await normalize(
+      [ai, human, existingResult],
+      new Map([['B', persistedToolMessage('B')]]),
+    );
 
-    expect(messageShape(normalized)).toEqual(['ai:A', 'tool:A']);
-    expect(retained.tool_calls.map((call) => call.id)).toEqual(['A']);
-    expect((retained.additional_kwargs.tool_calls as Array<{ id: string }>).map((call) => call.id)).toEqual(['A']);
-    expect(retained.additional_kwargs.__openai_function_call_ids__).toEqual({ A: 'output_A' });
-    expect(loadToolResults).toHaveBeenCalledWith(['A']);
-    expect(isToolCallHistoryValid(normalized)).toBe(true);
-  });
-
-  it('deletes an empty duplicate-only AI message but retains duplicate-only text as a normal AI message', async () => {
-    const prefix = [aiMessage('ai_1', ['A']), toolMessage('A')];
-    const empty = await normalize([...prefix, aiMessage('ai_empty', ['A'])]);
-    const text = await normalize([...prefix, aiMessage('ai_text', ['A'], 'interrupted text')]);
-
-    expect(messageShape(empty.normalized)).toEqual(['ai:A', 'tool:A']);
-    expect(messageShape(text.normalized)).toEqual(['ai:A', 'tool:A', 'ai:']);
-    expect((text.normalized[2] as AIMessage).content).toBe('interrupted text');
-    expect((text.normalized[2] as AIMessage).additional_kwargs).toEqual({});
+    expect(messageShape(normalized)).toEqual(['ai:A,B', 'tool:A', 'tool:B', 'human']);
+    expect(normalized[0]).toBe(ai);
+    expect(normalized[1]).toBe(existingResult);
+    expect(ai.content).toBe(content);
+    expect(ai.tool_calls.map((call) => call.id)).toEqual(['A', 'B']);
+    expect((ai.additional_kwargs.tool_calls as Array<{ id: string }>).map((call) => call.id)).toEqual(['A', 'B']);
+    expect(ai.additional_kwargs.__openai_function_call_ids__).toEqual({ A: 'output_A', B: 'output_B' });
+    expect(loadToolResults).toHaveBeenCalledWith(['B']);
   });
 
   it('removes orphan and duplicate results, preserving only the first matching object', async () => {
@@ -333,7 +319,7 @@ describe('toolResultIntegrityMiddleware', () => {
     );
   });
 
-  it('sanitizes inconsistent raw calls defensively without creating false results', async () => {
+  it('leaves raw-only AI messages unchanged and does not create false results', async () => {
     const rawOnly = new AIMessage({
       id: 'raw_only',
       content: '',
@@ -346,7 +332,11 @@ describe('toolResultIntegrityMiddleware', () => {
     const { normalized, loadToolResults } = await normalize([rawOnly, system]);
 
     expect(messageShape(normalized)).toEqual(['ai:', 'system']);
-    expect((normalized[0] as AIMessage).additional_kwargs).toEqual({ reasoning_content: 'preserve' });
+    expect(normalized[0]).toBe(rawOnly);
+    expect(rawOnly.additional_kwargs).toEqual({
+      tool_calls: [{ ...rawToolCall('A'), function: { name: 'tool_A', arguments: '{bad json' } }],
+      reasoning_content: 'preserve',
+    });
     expect(loadToolResults).not.toHaveBeenCalled();
     expect(normalized.some(ToolMessage.isInstance)).toBe(false);
   });
@@ -401,13 +391,19 @@ describe('toolResultIntegrityMiddleware', () => {
     ]);
     const providerMessages = convertMessagesToCompletionsMessageParams({ messages: normalized });
 
-    expect(providerMessages.map((message) => message.role)).toEqual(['assistant', 'tool', 'tool', 'user']);
-    expect(providerMessages[1]).toMatchObject({ role: 'tool', tool_call_id: 'A' });
-    expect(providerMessages[2]).toMatchObject({ role: 'tool', tool_call_id: 'B' });
+    expect(providerMessages[0].role).toBe('assistant');
+    expect(providerMessages.at(-1)?.role).toBe('user');
+    expect(
+      new Set(
+        providerMessages
+          .filter((message) => message.role === 'tool')
+          .map((message) => ('tool_call_id' in message ? message.tool_call_id : undefined)),
+      ),
+    ).toEqual(new Set(['A', 'B']));
     expect(isToolCallHistoryValid(normalized)).toBe(true);
   });
 
-  it('produces strict OpenAI and DeepSeek Responses function call output ordering', async () => {
+  it('produces complete OpenAI and DeepSeek Responses function call outputs before the next user message', async () => {
     const { normalized } = await normalize([
       aiMessage('ai_1', ['A', 'B']),
       new HumanMessage('must come after outputs'),
@@ -417,18 +413,15 @@ describe('toolResultIntegrityMiddleware', () => {
       zdrEnabled: false,
       messages: normalized,
     });
-    const functionItems = input.filter((item) => item.type === 'function_call' || item.type === 'function_call_output');
+    const functionCalls = input.filter((item) => item.type === 'function_call');
+    const functionOutputs = input.filter((item) => item.type === 'function_call_output');
 
-    expect(functionItems.map((item) => [item.type, 'call_id' in item ? item.call_id : undefined])).toEqual([
-      ['function_call', 'A'],
-      ['function_call', 'B'],
-      ['function_call_output', 'A'],
-      ['function_call_output', 'B'],
-    ]);
+    expect(new Set(functionCalls.map((item) => item.call_id))).toEqual(new Set(['A', 'B']));
+    expect(new Set(functionOutputs.map((item) => item.call_id))).toEqual(new Set(['A', 'B']));
     expect(input.at(-1)).toMatchObject({ type: 'message', role: 'user' });
   });
 
-  it('produces strict Anthropic and Bedrock-compatible tool use/result ordering', async () => {
+  it('produces complete Anthropic and Bedrock-compatible tool results before the next user message', async () => {
     const { normalized } = await normalize([aiMessage('ai_1', ['A']), new HumanMessage('must come after result')]);
     const payload = convertPromptToAnthropic(new ChatPromptValue(normalized));
 

--- a/packages/plugins/@nocobase/plugin-ai/src/server/ai-employees/ai-employee.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/ai-employees/ai-employee.ts
@@ -29,6 +29,7 @@ import {
   conversationMiddleware,
   skillToolBindingMiddleware,
   toolCallSanitizerMiddleware,
+  toolResultIntegrityMiddleware,
   toolCallStatusMiddleware,
   toolInteractionMiddleware,
   workflowHistoryMiddleware,
@@ -1124,6 +1125,7 @@ If information is missing, clearly state it in the summary.</Important>`;
           role: 'tool',
           content: { type: 'text', content: ABORTED_TOOL_CALL_CONTENT },
           metadata: {
+            id: `aborted-tool:${aiMessage.id}:${toolCall.toolCallId}`,
             model,
             provider: providerName,
             llmService,
@@ -1347,6 +1349,45 @@ If information is missing, clearly state it in the summary.</Important>`;
       })
     ).map((it) => it.toJSON());
     return new Map(list.map((it) => [it.toolCallId, it]));
+  }
+
+  async getToolCallResults(toolCallIds: string[]): Promise<Map<string, AIToolMessage>> {
+    if (!toolCallIds.length) {
+      return new Map();
+    }
+    type PersistedToolResult = AIToolMessage & { updatedAt?: string | Date };
+    const list = (
+      await this.aiToolMessagesModel.findAll<Model<PersistedToolResult>>({
+        where: {
+          sessionId: this.sessionId,
+          toolCallId: {
+            [Op.in]: toolCallIds,
+          },
+        },
+      })
+    ).map((item) => item.toJSON() as PersistedToolResult);
+    const invokeStatusPriority = { confirmed: 2, done: 1 } as const;
+    const results = new Map<string, PersistedToolResult>();
+
+    for (const item of list) {
+      if (item.invokeStatus !== 'confirmed' && item.invokeStatus !== 'done') {
+        continue;
+      }
+      const existing = results.get(item.toolCallId);
+      if (!existing) {
+        results.set(item.toolCallId, item);
+        continue;
+      }
+      const priority = invokeStatusPriority[item.invokeStatus];
+      const existingPriority = invokeStatusPriority[existing.invokeStatus as 'confirmed' | 'done'];
+      const updatedAt = item.updatedAt ? new Date(item.updatedAt).getTime() : 0;
+      const existingUpdatedAt = existing.updatedAt ? new Date(existing.updatedAt).getTime() : 0;
+      if (priority > existingPriority || (priority === existingPriority && updatedAt > existingUpdatedAt)) {
+        results.set(item.toolCallId, item);
+      }
+    }
+
+    return results;
   }
 
   async cancelToolCall() {
@@ -1576,8 +1617,10 @@ If information is missing, clearly state it in the summary.</Important>`;
       }
       if (msg.role === 'tool') {
         formattedMessages.push({
+          id: msg.metadata?.id,
           role: 'tool',
           content,
+          name: msg.metadata?.toolName,
           tool_call_id: msg.metadata?.toolCallId,
         });
         continue;
@@ -1870,6 +1913,21 @@ If information is missing, clearly state it in the summary.</Important>`;
       ...(inWorkflow ? [workflowHistoryMiddleware(this, this.db)] : []),
       conversationMiddleware(this, { providerName, provider, llmService, model, messageId, agentThread }),
       toolCallSanitizerMiddleware({ logger: this.logger }),
+      toolResultIntegrityMiddleware({
+        sessionId: this.sessionId,
+        logger: this.logger,
+        loadToolResults: async (toolCallIds) => {
+          try {
+            return await this.getToolCallResults(toolCallIds);
+          } catch (error) {
+            this.logger.warn('Failed to load persisted tool results before model call', {
+              sessionId: this.sessionId,
+              error,
+            });
+            return new Map();
+          }
+        },
+      }),
     ];
   }
 

--- a/packages/plugins/@nocobase/plugin-ai/src/server/ai-employees/ai-employee.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/ai-employees/ai-employee.ts
@@ -7,7 +7,7 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import { Model, Op, Transaction } from '@nocobase/database';
+import { Model, Op, Transaction, UniqueConstraintError } from '@nocobase/database';
 import { LLMProvider } from '../llm-providers/provider';
 import { Database } from '@nocobase/database';
 import PluginAIServer from '../plugin';
@@ -37,6 +37,7 @@ import { listSystemTools, SkillsEntry, SYSTEM_TOOLS, ToolsEntry, ToolsFilter, To
 import { AIToolMessage } from '../types/ai-message.type';
 import { SequelizeCollectionSaver } from './checkpoints';
 import { createAgent as createLangChainAgent } from 'langchain';
+import type { AIMessage as LangChainAIMessage } from '@langchain/core/messages';
 import { Command } from '@langchain/langgraph';
 import { concat } from '@langchain/core/utils/stream';
 import { convertAIMessage } from './utils';
@@ -94,6 +95,21 @@ type InterruptAction = {
     username: string;
   };
 };
+
+export type PersistAIMessageOptions = {
+  values: AIMessageInput;
+  langChainMessageId: string;
+  toolCalls: AIToolCall[];
+  knownMessageId?: string;
+};
+
+export type PersistAIMessageResult = {
+  message: AIMessage;
+  initializedToolCalls: Model<AIToolMessage>[];
+  created: boolean;
+};
+
+const ABORTED_TOOL_CALL_CONTENT = 'The tool call was interrupted because the conversation was aborted.';
 
 export class AIEmployee {
   sessionId: string;
@@ -530,6 +546,7 @@ export class AIEmployee {
     },
   ) {
     const aiMessageIdMap = new Map<string, string>();
+    const persistedAIMessageIdMap = new Map<string, string>();
     const { signal, providerName, llmService, model, provider, responseMetadata, allowEmpty = false } = options;
 
     const reasoningState = new ReasoningStreamState();
@@ -544,38 +561,38 @@ export class AIEmployee {
       }
     };
     let gathered: any;
-    signal.addEventListener('abort', async () => {
-      try {
-        await stopAllReasoning();
-        if (gathered?.type === 'ai') {
-          const values = convertAIMessage({
-            aiEmployee: this,
-            providerName,
-            provider,
-            llmService,
-            model,
-            aiMessage: gathered,
-          });
-          if (values) {
-            values.metadata.interrupted = true;
+    let abortFinalization: Promise<void> | undefined;
+    signal.addEventListener(
+      'abort',
+      () => {
+        abortFinalization = (async () => {
+          try {
+            await stopAllReasoning();
+            if (gathered?.type === 'ai') {
+              await this.finalizeAbortedAIMessage({
+                aiMessage: gathered,
+                providerName,
+                provider,
+                llmService,
+                model,
+                knownMessageId: persistedAIMessageIdMap.get(gathered.id),
+              });
+            }
+          } catch (e) {
+            this.logger.error('Fail to save message after conversation abort', gathered);
+          } finally {
+            await this.aiConversationsRepo.update({
+              values: { llmActiveState: 'idle', read: true },
+              filter: {
+                sessionId: this.sessionId,
+              },
+            });
+            await this.streamCached.clear();
           }
-
-          await this.aiChatConversation.withTransaction(async (conversation, transaction) => {
-            const result: AIMessage = await conversation.addMessages(values);
-          });
-        }
-      } catch (e) {
-        this.logger.error('Fail to save message after conversation abort', gathered);
-      } finally {
-        await this.aiConversationsRepo.update({
-          values: { llmActiveState: 'idle', read: true },
-          filter: {
-            sessionId: this.sessionId,
-          },
-        });
-        await this.streamCached.clear();
-      }
-    });
+        })();
+      },
+      { once: true },
+    );
 
     try {
       const aiEmployeeConversation = {
@@ -644,6 +661,7 @@ export class AIEmployee {
           if (chunks.action === 'AfterAIMessageSaved') {
             await this.streamCached.skipped();
             aiMessageIdMap.set(currentConversation.sessionId, chunks.body.messageId);
+            persistedAIMessageIdMap.set(chunks.body.id, chunks.body.messageId);
 
             const data = responseMetadata.get(chunks.body.id);
             if (data) {
@@ -752,6 +770,7 @@ export class AIEmployee {
         this.sendErrorResponse(provider.parseResponseError(err));
       }
     } finally {
+      await abortFinalization;
       if (this.from === 'main-agent') {
         this.ctx.res.end();
       }
@@ -959,6 +978,187 @@ If information is missing, clearly state it in the summary.</Important>`;
   }
 
   // === Tool calls ===
+  private async withLockedConversation<T>(
+    callback: (conversation: AIChatConversation, transaction: Transaction) => Promise<T>,
+  ): Promise<T> {
+    for (let attempt = 0; attempt < 2; attempt++) {
+      try {
+        return await this.aiChatConversation.withTransaction(async (conversation, transaction) => {
+          const lockedConversation = await this.aiConversationsModel.findOne({
+            where: { sessionId: this.sessionId },
+            transaction,
+            lock: transaction.LOCK.UPDATE,
+          });
+          if (!lockedConversation) {
+            throw new Error(`AI conversation ${this.sessionId} not found`);
+          }
+          return await callback(conversation, transaction);
+        });
+      } catch (error) {
+        if (!(error instanceof UniqueConstraintError) || attempt === 1) {
+          throw error;
+        }
+      }
+    }
+    throw new Error(`Failed to persist AI conversation ${this.sessionId}`);
+  }
+
+  private async findPersistedAIMessage(
+    transaction: Transaction,
+    langChainMessageId: string,
+    knownMessageId?: string,
+  ): Promise<Model<AIMessage> | undefined> {
+    if (knownMessageId) {
+      const knownMessage = await this.aiMessagesModel.findOne({
+        where: { sessionId: this.sessionId, messageId: knownMessageId },
+        transaction,
+      });
+      if (knownMessage?.get('metadata')?.id === langChainMessageId) {
+        return knownMessage;
+      }
+    }
+
+    const messages = await this.aiMessagesModel.findAll({
+      where: { sessionId: this.sessionId, role: this.employee.username },
+      order: [['messageId', 'DESC']],
+      transaction,
+    });
+    return messages.find((message) => message.get('metadata')?.id === langChainMessageId);
+  }
+
+  private async persistAIMessageInTransaction(
+    conversation: AIChatConversation,
+    transaction: Transaction,
+    options: PersistAIMessageOptions,
+  ): Promise<PersistAIMessageResult> {
+    const existingMessage = await this.findPersistedAIMessage(
+      transaction,
+      options.langChainMessageId,
+      options.knownMessageId,
+    );
+    if (existingMessage) {
+      const message = existingMessage.toJSON() as AIMessage;
+      const initializedToolCalls = await this.aiToolMessagesModel.findAll<Model<AIToolMessage>>({
+        where: { sessionId: this.sessionId, messageId: message.messageId },
+        transaction,
+      });
+      return { message, initializedToolCalls, created: false };
+    }
+
+    const message = await conversation.addMessages(options.values);
+    const initializedToolCalls = options.toolCalls.length
+      ? await this.initToolCall(transaction, message.messageId, options.toolCalls)
+      : [];
+    return { message, initializedToolCalls, created: true };
+  }
+
+  async persistAIMessage(options: PersistAIMessageOptions): Promise<PersistAIMessageResult> {
+    return await this.withLockedConversation(async (conversation, transaction) => {
+      return await this.persistAIMessageInTransaction(conversation, transaction, options);
+    });
+  }
+
+  async finalizeAbortedAIMessage({
+    aiMessage,
+    providerName,
+    provider,
+    llmService,
+    model,
+    knownMessageId,
+  }: {
+    aiMessage: LangChainAIMessage;
+    providerName: string;
+    provider: LLMProvider;
+    llmService?: string;
+    model: string;
+    knownMessageId?: string;
+  }): Promise<PersistAIMessageResult | undefined> {
+    const values = convertAIMessage({
+      aiEmployee: this,
+      providerName,
+      provider,
+      llmService,
+      model,
+      aiMessage,
+    });
+    if (!values) {
+      return;
+    }
+    values.metadata = { ...values.metadata, interrupted: true };
+    const toolCalls = (aiMessage.tool_calls ?? []) as AIToolCall[];
+
+    return await this.withLockedConversation(async (conversation, transaction) => {
+      const result = await this.persistAIMessageInTransaction(conversation, transaction, {
+        values,
+        langChainMessageId: aiMessage.id,
+        toolCalls,
+        knownMessageId,
+      });
+
+      const unfinishedToolCalls = result.initializedToolCalls
+        .map((toolCall) => toolCall.toJSON() as AIToolMessage)
+        .filter((toolCall) => toolCall.invokeStatus !== 'confirmed');
+
+      if (
+        !result.created &&
+        (!result.initializedToolCalls.length || unfinishedToolCalls.length) &&
+        !result.message.metadata?.interrupted
+      ) {
+        const metadata = { ...result.message.metadata, interrupted: true };
+        await this.aiMessagesModel.update(
+          { metadata },
+          { where: { sessionId: this.sessionId, messageId: result.message.messageId }, transaction },
+        );
+        result.message.metadata = metadata;
+      }
+
+      if (!unfinishedToolCalls.length) {
+        return result;
+      }
+
+      const persistedToolCalls = result.message.toolCalls ?? toolCalls;
+      const toolCallMap = new Map(persistedToolCalls.map((toolCall) => [toolCall.id, toolCall]));
+      const now = new Date();
+      await conversation.addMessages(
+        unfinishedToolCalls.map((toolCall) => ({
+          role: 'tool',
+          content: { type: 'text', content: ABORTED_TOOL_CALL_CONTENT },
+          metadata: {
+            model,
+            provider: providerName,
+            llmService,
+            messageId: result.message.messageId,
+            toolCallId: toolCall.toolCallId,
+            toolName: toolCall.toolName,
+            toolCall: toolCallMap.get(toolCall.toolCallId),
+            autoCall: toolCall.auto,
+          },
+        })),
+      );
+
+      for (const toolCall of unfinishedToolCalls) {
+        await this.aiToolMessagesModel.update(
+          {
+            invokeStatus: 'confirmed',
+            status: 'error',
+            content: ABORTED_TOOL_CALL_CONTENT,
+            invokeStartTime: toolCall.invokeStartTime ?? now,
+            invokeEndTime: now,
+          },
+          {
+            where: {
+              id: toolCall.id,
+              invokeStatus: { [Op.ne]: 'confirmed' },
+            },
+            transaction,
+          },
+        );
+      }
+
+      return result;
+    });
+  }
+
   async initToolCall(
     transaction: Transaction,
     messageId: string,
@@ -1733,6 +1933,10 @@ If information is missing, clearly state it in the summary.</Important>`;
 
   private get aiMessagesRepo() {
     return this.ctx.db.getRepository('aiMessages');
+  }
+
+  private get aiConversationsModel() {
+    return this.ctx.db.getModel('aiConversations');
   }
 
   private get aiMessagesModel() {

--- a/packages/plugins/@nocobase/plugin-ai/src/server/ai-employees/ai-employee.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/ai-employees/ai-employee.ts
@@ -131,6 +131,7 @@ export class AIEmployee {
   private tools: { name: string }[];
   private inWorkflow?: boolean;
   private streamCached: LLMStreamCached;
+  private static conversationPersistenceQueues = new WeakMap<Database, Map<string, Promise<void>>>();
 
   constructor({
     ctx,
@@ -982,26 +983,43 @@ If information is missing, clearly state it in the summary.</Important>`;
   private async withLockedConversation<T>(
     callback: (conversation: AIChatConversation, transaction: Transaction) => Promise<T>,
   ): Promise<T> {
-    for (let attempt = 0; attempt < 2; attempt++) {
-      try {
-        return await this.aiChatConversation.withTransaction(async (conversation, transaction) => {
-          const lockedConversation = await this.aiConversationsModel.findOne({
-            where: { sessionId: this.sessionId },
-            transaction,
-            lock: transaction.LOCK.UPDATE,
+    const persistenceQueues = AIEmployee.conversationPersistenceQueues.get(this.db) ?? new Map();
+    AIEmployee.conversationPersistenceQueues.set(this.db, persistenceQueues);
+    const previous = persistenceQueues.get(this.sessionId) ?? Promise.resolve();
+    let release!: () => void;
+    const current = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    persistenceQueues.set(this.sessionId, current);
+    await previous;
+
+    try {
+      for (let attempt = 0; attempt < 2; attempt++) {
+        try {
+          return await this.aiChatConversation.withTransaction(async (conversation, transaction) => {
+            const lockedConversation = await this.aiConversationsModel.findOne({
+              where: { sessionId: this.sessionId },
+              transaction,
+              lock: transaction.LOCK.UPDATE,
+            });
+            if (!lockedConversation) {
+              throw new Error(`AI conversation ${this.sessionId} not found`);
+            }
+            return await callback(conversation, transaction);
           });
-          if (!lockedConversation) {
-            throw new Error(`AI conversation ${this.sessionId} not found`);
+        } catch (error) {
+          if (!(error instanceof UniqueConstraintError) || attempt === 1) {
+            throw error;
           }
-          return await callback(conversation, transaction);
-        });
-      } catch (error) {
-        if (!(error instanceof UniqueConstraintError) || attempt === 1) {
-          throw error;
         }
       }
+      throw new Error(`Failed to persist AI conversation ${this.sessionId}`);
+    } finally {
+      release();
+      if (persistenceQueues.get(this.sessionId) === current) {
+        persistenceQueues.delete(this.sessionId);
+      }
     }
-    throw new Error(`Failed to persist AI conversation ${this.sessionId}`);
   }
 
   private async findPersistedAIMessage(

--- a/packages/plugins/@nocobase/plugin-ai/src/server/ai-employees/middleware/conversation.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/ai-employees/middleware/conversation.ts
@@ -191,33 +191,32 @@ export const conversationMiddleware = (
         const toolCalls = aiMessage.tool_calls;
         const values = convertAIMessage(aiMessage);
         if (values) {
-          await aiEmployee.aiChatConversation.withTransaction(async (conversation, transaction) => {
-            const result: AIConversationMessage = await conversation.addMessages(values);
-            newState.messageId = result.messageId;
-            if (toolCalls?.length) {
-              const toolsMap = await aiEmployee.getToolsMap();
-              const initializedToolCalls = await aiEmployee.initToolCall(
-                transaction,
-                result.messageId,
-                toolCalls as any,
-              );
-              fillToolCall(result, toolsMap, initializedToolCalls, toolCalls as any);
-            }
+          const result = await aiEmployee.persistAIMessage({
+            values,
+            langChainMessageId: aiMessage.id,
+            toolCalls: (toolCalls ?? []) as AIToolCall[],
           });
-
+          newState.messageId = result.message.messageId;
           if (toolCalls?.length) {
+            const toolsMap = await aiEmployee.getToolsMap();
+            fillToolCall(result.message, toolsMap, result.initializedToolCalls, toolCalls as AIToolCall[]);
+          }
+
+          if (result.created) {
+            if (toolCalls?.length) {
+              runtime.writer?.({
+                action: 'initToolCalls',
+                body: { toolCalls },
+                currentConversation,
+              });
+            }
+
             runtime.writer?.({
-              action: 'initToolCalls',
-              body: { toolCalls },
+              action: 'AfterAIMessageSaved',
+              body: { id: aiMessage.id, messageId: newState.messageId },
               currentConversation,
             });
           }
-
-          runtime.writer?.({
-            action: 'AfterAIMessageSaved',
-            body: { id: aiMessage.id, messageId: newState.messageId },
-            currentConversation,
-          });
         }
 
         return newState;

--- a/packages/plugins/@nocobase/plugin-ai/src/server/ai-employees/middleware/index.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/ai-employees/middleware/index.ts
@@ -10,5 +10,6 @@
 export * from './conversation';
 export * from './skill-tools';
 export * from './tool-call-sanitizer';
+export * from './tool-result-integrity';
 export * from './tools';
 export * from './workflow-history';

--- a/packages/plugins/@nocobase/plugin-ai/src/server/ai-employees/middleware/tool-result-integrity.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/ai-employees/middleware/tool-result-integrity.ts
@@ -1,0 +1,391 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { AIMessage, BaseMessage, ToolMessage } from '@langchain/core/messages';
+import { createMiddleware } from 'langchain';
+import type { AIToolMessage } from '../../types/ai-message.type';
+
+const SYNTHETIC_TOOL_RESULT_ERROR = 'Tool execution was interrupted before a result was recorded.';
+
+type ToolResultIntegrityLogger = {
+  warn: (message: string, meta?: Record<string, unknown>) => void;
+};
+
+export type NormalizeToolCallHistoryOptions = {
+  sessionId: string;
+  logger?: ToolResultIntegrityLogger;
+  loadToolResults: (toolCallIds: string[]) => Promise<Map<string, AIToolMessage>>;
+};
+
+type RawToolCall = Record<string, unknown> & {
+  id: string;
+  type: 'function';
+  function: { name: string; arguments: string };
+};
+
+type NormalizationStats = {
+  messageCount: number;
+  toolCallCount: number;
+  missingResultCount: number;
+  misplacedResultCount: number;
+  duplicateToolCallCount: number;
+  orphanResultCount: number;
+  restoredResultCount: number;
+  syntheticResultCount: number;
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const getRawToolCalls = (message: AIMessage): unknown[] | undefined => {
+  if (!Object.prototype.hasOwnProperty.call(message.additional_kwargs, 'tool_calls')) {
+    return undefined;
+  }
+  return Array.isArray(message.additional_kwargs.tool_calls) ? message.additional_kwargs.tool_calls : [];
+};
+
+const getRawToolCallId = (toolCall: unknown): string | undefined => {
+  if (!isRecord(toolCall)) {
+    return;
+  }
+  return typeof toolCall.id === 'string' && toolCall.id ? toolCall.id : undefined;
+};
+
+const areParsedAndRawToolCallsConsistent = (message: AIMessage): boolean => {
+  const parsedToolCalls = message.tool_calls ?? [];
+  const parsedIds = new Set<string>();
+  for (const toolCall of parsedToolCalls) {
+    if (!toolCall.id || parsedIds.has(toolCall.id)) {
+      return false;
+    }
+    parsedIds.add(toolCall.id);
+  }
+
+  const functionCallIds = message.additional_kwargs.__openai_function_call_ids__;
+  const hasConsistentFunctionCallIds =
+    functionCallIds === undefined ||
+    (isRecord(functionCallIds) && Object.keys(functionCallIds).every((id) => parsedIds.has(id)));
+  if (
+    Object.prototype.hasOwnProperty.call(message.additional_kwargs, 'tool_calls') &&
+    !Array.isArray(message.additional_kwargs.tool_calls)
+  ) {
+    return false;
+  }
+  const rawToolCalls = getRawToolCalls(message);
+  if (rawToolCalls === undefined) {
+    return hasConsistentFunctionCallIds;
+  }
+
+  const rawIds = new Set<string>();
+  for (const rawToolCall of rawToolCalls) {
+    const id = getRawToolCallId(rawToolCall);
+    if (!id || rawIds.has(id)) {
+      return false;
+    }
+    rawIds.add(id);
+  }
+
+  if (rawIds.size !== parsedIds.size || !Array.from(parsedIds).every((id) => rawIds.has(id))) {
+    return false;
+  }
+
+  return hasConsistentFunctionCallIds;
+};
+
+export const isToolCallHistoryValid = (messages: readonly BaseMessage[]): boolean => {
+  const seenToolCallIds = new Set<string>();
+
+  for (let index = 0; index < messages.length; index++) {
+    const message = messages[index];
+    if (ToolMessage.isInstance(message)) {
+      return false;
+    }
+    if (!AIMessage.isInstance(message)) {
+      continue;
+    }
+
+    const toolCalls = message.tool_calls ?? [];
+    if (!areParsedAndRawToolCallsConsistent(message)) {
+      return false;
+    }
+    if (!toolCalls.length) {
+      continue;
+    }
+
+    for (const toolCall of toolCalls) {
+      if (!toolCall.id || seenToolCallIds.has(toolCall.id)) {
+        return false;
+      }
+      seenToolCallIds.add(toolCall.id);
+    }
+
+    for (const toolCall of toolCalls) {
+      index++;
+      if (index >= messages.length) {
+        return false;
+      }
+      const result = messages[index];
+      if (!ToolMessage.isInstance(result) || result.tool_call_id !== toolCall.id) {
+        return false;
+      }
+    }
+  }
+
+  return true;
+};
+
+const hasMessageContent = (content: BaseMessage['content']): boolean => {
+  if (typeof content === 'string') {
+    return content.length > 0;
+  }
+  return content.length > 0;
+};
+
+const filterRawToolCalls = (rawToolCalls: unknown[], retainedIds: Set<string>): RawToolCall[] | undefined => {
+  const seenIds = new Set<string>();
+  const retainedRawToolCalls: RawToolCall[] = [];
+  for (const rawToolCall of rawToolCalls) {
+    const id = getRawToolCallId(rawToolCall);
+    if (!id || !retainedIds.has(id) || seenIds.has(id) || !isRecord(rawToolCall)) {
+      continue;
+    }
+    seenIds.add(id);
+    retainedRawToolCalls.push(rawToolCall as RawToolCall);
+  }
+  return seenIds.size === retainedIds.size ? retainedRawToolCalls : undefined;
+};
+
+const cloneAIMessageWithToolCalls = (message: AIMessage, toolCalls: AIMessage['tool_calls']): AIMessage => {
+  const retainedIds = new Set(toolCalls.map((toolCall) => toolCall.id).filter((id): id is string => Boolean(id)));
+  const additionalKwargs = { ...message.additional_kwargs };
+  const rawToolCalls = getRawToolCalls(message);
+  if (rawToolCalls !== undefined) {
+    const retainedRawToolCalls = filterRawToolCalls(rawToolCalls, retainedIds);
+    if (retainedRawToolCalls?.length) {
+      additionalKwargs.tool_calls = retainedRawToolCalls;
+    } else {
+      delete additionalKwargs.tool_calls;
+    }
+  }
+
+  const functionCallIds = additionalKwargs.__openai_function_call_ids__;
+  if (isRecord(functionCallIds)) {
+    const retainedFunctionCallIds = Object.fromEntries(
+      Object.entries(functionCallIds).filter(([callId]) => retainedIds.has(callId)),
+    );
+    if (Object.keys(retainedFunctionCallIds).length) {
+      additionalKwargs.__openai_function_call_ids__ = retainedFunctionCallIds;
+    } else {
+      delete additionalKwargs.__openai_function_call_ids__;
+    }
+  } else if (functionCallIds !== undefined) {
+    delete additionalKwargs.__openai_function_call_ids__;
+  }
+
+  return new AIMessage({
+    id: message.id,
+    content: message.content,
+    name: message.name,
+    additional_kwargs: additionalKwargs,
+    response_metadata: message.response_metadata,
+    tool_calls: toolCalls,
+    invalid_tool_calls: message.invalid_tool_calls,
+    usage_metadata: message.usage_metadata,
+  });
+};
+
+const serializeToolResultContent = (content: unknown): string => {
+  if (typeof content === 'string') {
+    return content;
+  }
+  return JSON.stringify(content ?? null);
+};
+
+const createSyntheticToolResult = (sessionId: string, toolCall: NonNullable<AIMessage['tool_calls']>[number]) =>
+  new ToolMessage({
+    id: `synthetic-tool-result:${sessionId}:${toolCall.id}`,
+    tool_call_id: toolCall.id,
+    name: toolCall.name,
+    status: 'error',
+    content: JSON.stringify({
+      status: 'error',
+      error: SYNTHETIC_TOOL_RESULT_ERROR,
+    }),
+  });
+
+const createRestoredToolResult = (
+  sessionId: string,
+  toolCall: NonNullable<AIMessage['tool_calls']>[number],
+  persisted?: AIToolMessage,
+): ToolMessage | undefined => {
+  if (!persisted || (persisted.invokeStatus !== 'confirmed' && persisted.invokeStatus !== 'done')) {
+    return;
+  }
+  try {
+    return new ToolMessage({
+      id: `restored-tool-result:${sessionId}:${toolCall.id}`,
+      tool_call_id: toolCall.id,
+      name: toolCall.name,
+      status: persisted.status === 'error' ? 'error' : 'success',
+      content: serializeToolResultContent(persisted.content),
+    });
+  } catch {
+    return;
+  }
+};
+
+const countMisplacedResults = (messages: readonly BaseMessage[]): number => {
+  let misplacedResultCount = 0;
+  for (let index = 0; index < messages.length; index++) {
+    const message = messages[index];
+    if (!AIMessage.isInstance(message) || !message.tool_calls?.length) {
+      continue;
+    }
+    for (let toolCallIndex = 0; toolCallIndex < message.tool_calls.length; toolCallIndex++) {
+      const toolCall = message.tool_calls[toolCallIndex];
+      const result = messages[index + toolCallIndex + 1];
+      if (!ToolMessage.isInstance(result) || result.tool_call_id !== toolCall.id) {
+        misplacedResultCount++;
+      }
+    }
+  }
+  return misplacedResultCount;
+};
+
+export const normalizeToolCallHistory = async (
+  messages: readonly BaseMessage[],
+  options: NormalizeToolCallHistoryOptions,
+): Promise<BaseMessage[]> => {
+  const toolResultsByCallId = new Map<string, ToolMessage[]>();
+  const referencedToolCallIds = new Set<string>();
+  let toolCallCount = 0;
+  let toolResultCount = 0;
+
+  for (const message of messages) {
+    if (AIMessage.isInstance(message)) {
+      for (const toolCall of message.tool_calls ?? []) {
+        toolCallCount++;
+        if (toolCall.id) {
+          referencedToolCallIds.add(toolCall.id);
+        }
+      }
+    } else if (ToolMessage.isInstance(message)) {
+      toolResultCount++;
+      if (message.tool_call_id) {
+        const results = toolResultsByCallId.get(message.tool_call_id) ?? [];
+        results.push(message);
+        toolResultsByCallId.set(message.tool_call_id, results);
+      }
+    }
+  }
+
+  const missingToolCallIds = Array.from(referencedToolCallIds).filter((id) => !toolResultsByCallId.has(id));
+  const persistedResults = missingToolCallIds.length ? await options.loadToolResults(missingToolCallIds) : new Map();
+  const normalized: BaseMessage[] = [];
+  const seenToolCallIds = new Set<string>();
+  const nextToolResultIndexByCallId = new Map<string, number>();
+  let duplicateToolCallCount = 0;
+  let restoredResultCount = 0;
+  let syntheticResultCount = 0;
+  let consumedExistingResultCount = 0;
+
+  for (const message of messages) {
+    if (ToolMessage.isInstance(message)) {
+      continue;
+    }
+    if (!AIMessage.isInstance(message)) {
+      normalized.push(message);
+      continue;
+    }
+
+    const toolCalls = message.tool_calls ?? [];
+    if (!toolCalls.length) {
+      const functionCallIds = message.additional_kwargs.__openai_function_call_ids__;
+      if (
+        Object.prototype.hasOwnProperty.call(message.additional_kwargs, 'tool_calls') ||
+        functionCallIds !== undefined
+      ) {
+        normalized.push(cloneAIMessageWithToolCalls(message, []));
+      } else {
+        normalized.push(message);
+      }
+      continue;
+    }
+
+    const retainedToolCalls = toolCalls.filter((toolCall) => {
+      if (!toolCall.id || seenToolCallIds.has(toolCall.id)) {
+        duplicateToolCallCount++;
+        return false;
+      }
+      seenToolCallIds.add(toolCall.id);
+      return true;
+    });
+
+    if (!retainedToolCalls.length) {
+      if (hasMessageContent(message.content)) {
+        normalized.push(cloneAIMessageWithToolCalls(message, []));
+      }
+      continue;
+    }
+
+    normalized.push(cloneAIMessageWithToolCalls(message, retainedToolCalls));
+    for (const toolCall of retainedToolCalls) {
+      const existingResults = toolResultsByCallId.get(toolCall.id);
+      const existingResultIndex = nextToolResultIndexByCallId.get(toolCall.id) ?? 0;
+      const existingResult = existingResults?.[existingResultIndex];
+      if (existingResult) {
+        nextToolResultIndexByCallId.set(toolCall.id, existingResultIndex + 1);
+        normalized.push(existingResult);
+        consumedExistingResultCount++;
+        continue;
+      }
+
+      const restoredResult = createRestoredToolResult(options.sessionId, toolCall, persistedResults.get(toolCall.id));
+      if (restoredResult) {
+        normalized.push(restoredResult);
+        restoredResultCount++;
+        continue;
+      }
+
+      normalized.push(createSyntheticToolResult(options.sessionId, toolCall));
+      syntheticResultCount++;
+    }
+  }
+
+  const totalToolResultCount = toolResultCount;
+  const stats: NormalizationStats = {
+    messageCount: messages.length,
+    toolCallCount,
+    missingResultCount: missingToolCallIds.length,
+    misplacedResultCount: countMisplacedResults(messages),
+    duplicateToolCallCount,
+    orphanResultCount: totalToolResultCount - consumedExistingResultCount,
+    restoredResultCount,
+    syntheticResultCount,
+  };
+  options.logger?.warn('Normalize invalid tool call history before model call', {
+    sessionId: options.sessionId,
+    ...stats,
+  });
+
+  return normalized;
+};
+
+export const toolResultIntegrityMiddleware = (options: NormalizeToolCallHistoryOptions) =>
+  createMiddleware({
+    name: 'ToolResultIntegrityMiddleware',
+    wrapModelCall: async (request, handler) => {
+      if (isToolCallHistoryValid(request.messages)) {
+        return handler(request);
+      }
+
+      request.messages = await normalizeToolCallHistory(request.messages, options);
+      return handler(request);
+    },
+  });

--- a/packages/plugins/@nocobase/plugin-ai/src/server/ai-employees/middleware/tool-result-integrity.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/ai-employees/middleware/tool-result-integrity.ts
@@ -125,15 +125,22 @@ export const isToolCallHistoryValid = (messages: readonly BaseMessage[]): boolea
       seenToolCallIds.add(toolCall.id);
     }
 
-    for (const toolCall of toolCalls) {
+    const expectedToolCallIds = new Set(toolCalls.map((toolCall) => toolCall.id));
+    const seenToolResultIds = new Set<string>();
+    for (let resultIndex = 0; resultIndex < toolCalls.length; resultIndex++) {
       index++;
       if (index >= messages.length) {
         return false;
       }
       const result = messages[index];
-      if (!ToolMessage.isInstance(result) || result.tool_call_id !== toolCall.id) {
+      if (
+        !ToolMessage.isInstance(result) ||
+        !expectedToolCallIds.has(result.tool_call_id) ||
+        seenToolResultIds.has(result.tool_call_id)
+      ) {
         return false;
       }
+      seenToolResultIds.add(result.tool_call_id);
     }
   }
 

--- a/packages/plugins/@nocobase/plugin-ai/src/server/ai-employees/middleware/tool-result-integrity.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/ai-employees/middleware/tool-result-integrity.ts
@@ -23,84 +23,20 @@ export type NormalizeToolCallHistoryOptions = {
   loadToolResults: (toolCallIds: string[]) => Promise<Map<string, AIToolMessage>>;
 };
 
-type RawToolCall = Record<string, unknown> & {
-  id: string;
-  type: 'function';
-  function: { name: string; arguments: string };
-};
-
 type NormalizationStats = {
   messageCount: number;
   toolCallCount: number;
   missingResultCount: number;
   misplacedResultCount: number;
-  duplicateToolCallCount: number;
   orphanResultCount: number;
   restoredResultCount: number;
   syntheticResultCount: number;
 };
 
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === 'object' && value !== null && !Array.isArray(value);
-
-const getRawToolCalls = (message: AIMessage): unknown[] | undefined => {
-  if (!Object.prototype.hasOwnProperty.call(message.additional_kwargs, 'tool_calls')) {
-    return undefined;
-  }
-  return Array.isArray(message.additional_kwargs.tool_calls) ? message.additional_kwargs.tool_calls : [];
-};
-
-const getRawToolCallId = (toolCall: unknown): string | undefined => {
-  if (!isRecord(toolCall)) {
-    return;
-  }
-  return typeof toolCall.id === 'string' && toolCall.id ? toolCall.id : undefined;
-};
-
-const areParsedAndRawToolCallsConsistent = (message: AIMessage): boolean => {
-  const parsedToolCalls = message.tool_calls ?? [];
-  const parsedIds = new Set<string>();
-  for (const toolCall of parsedToolCalls) {
-    if (!toolCall.id || parsedIds.has(toolCall.id)) {
-      return false;
-    }
-    parsedIds.add(toolCall.id);
-  }
-
-  const functionCallIds = message.additional_kwargs.__openai_function_call_ids__;
-  const hasConsistentFunctionCallIds =
-    functionCallIds === undefined ||
-    (isRecord(functionCallIds) && Object.keys(functionCallIds).every((id) => parsedIds.has(id)));
-  if (
-    Object.prototype.hasOwnProperty.call(message.additional_kwargs, 'tool_calls') &&
-    !Array.isArray(message.additional_kwargs.tool_calls)
-  ) {
-    return false;
-  }
-  const rawToolCalls = getRawToolCalls(message);
-  if (rawToolCalls === undefined) {
-    return hasConsistentFunctionCallIds;
-  }
-
-  const rawIds = new Set<string>();
-  for (const rawToolCall of rawToolCalls) {
-    const id = getRawToolCallId(rawToolCall);
-    if (!id || rawIds.has(id)) {
-      return false;
-    }
-    rawIds.add(id);
-  }
-
-  if (rawIds.size !== parsedIds.size || !Array.from(parsedIds).every((id) => rawIds.has(id))) {
-    return false;
-  }
-
-  return hasConsistentFunctionCallIds;
-};
+const getValidToolCalls = (message: AIMessage) =>
+  (message.tool_calls ?? []).filter((toolCall) => typeof toolCall.id === 'string' && toolCall.id.length > 0);
 
 export const isToolCallHistoryValid = (messages: readonly BaseMessage[]): boolean => {
-  const seenToolCallIds = new Set<string>();
-
   for (let index = 0; index < messages.length; index++) {
     const message = messages[index];
     if (ToolMessage.isInstance(message)) {
@@ -110,19 +46,9 @@ export const isToolCallHistoryValid = (messages: readonly BaseMessage[]): boolea
       continue;
     }
 
-    const toolCalls = message.tool_calls ?? [];
-    if (!areParsedAndRawToolCallsConsistent(message)) {
-      return false;
-    }
+    const toolCalls = getValidToolCalls(message);
     if (!toolCalls.length) {
       continue;
-    }
-
-    for (const toolCall of toolCalls) {
-      if (!toolCall.id || seenToolCallIds.has(toolCall.id)) {
-        return false;
-      }
-      seenToolCallIds.add(toolCall.id);
     }
 
     const expectedToolCallIds = new Set(toolCalls.map((toolCall) => toolCall.id));
@@ -145,66 +71,6 @@ export const isToolCallHistoryValid = (messages: readonly BaseMessage[]): boolea
   }
 
   return true;
-};
-
-const hasMessageContent = (content: BaseMessage['content']): boolean => {
-  if (typeof content === 'string') {
-    return content.length > 0;
-  }
-  return content.length > 0;
-};
-
-const filterRawToolCalls = (rawToolCalls: unknown[], retainedIds: Set<string>): RawToolCall[] | undefined => {
-  const seenIds = new Set<string>();
-  const retainedRawToolCalls: RawToolCall[] = [];
-  for (const rawToolCall of rawToolCalls) {
-    const id = getRawToolCallId(rawToolCall);
-    if (!id || !retainedIds.has(id) || seenIds.has(id) || !isRecord(rawToolCall)) {
-      continue;
-    }
-    seenIds.add(id);
-    retainedRawToolCalls.push(rawToolCall as RawToolCall);
-  }
-  return seenIds.size === retainedIds.size ? retainedRawToolCalls : undefined;
-};
-
-const cloneAIMessageWithToolCalls = (message: AIMessage, toolCalls: AIMessage['tool_calls']): AIMessage => {
-  const retainedIds = new Set(toolCalls.map((toolCall) => toolCall.id).filter((id): id is string => Boolean(id)));
-  const additionalKwargs = { ...message.additional_kwargs };
-  const rawToolCalls = getRawToolCalls(message);
-  if (rawToolCalls !== undefined) {
-    const retainedRawToolCalls = filterRawToolCalls(rawToolCalls, retainedIds);
-    if (retainedRawToolCalls?.length) {
-      additionalKwargs.tool_calls = retainedRawToolCalls;
-    } else {
-      delete additionalKwargs.tool_calls;
-    }
-  }
-
-  const functionCallIds = additionalKwargs.__openai_function_call_ids__;
-  if (isRecord(functionCallIds)) {
-    const retainedFunctionCallIds = Object.fromEntries(
-      Object.entries(functionCallIds).filter(([callId]) => retainedIds.has(callId)),
-    );
-    if (Object.keys(retainedFunctionCallIds).length) {
-      additionalKwargs.__openai_function_call_ids__ = retainedFunctionCallIds;
-    } else {
-      delete additionalKwargs.__openai_function_call_ids__;
-    }
-  } else if (functionCallIds !== undefined) {
-    delete additionalKwargs.__openai_function_call_ids__;
-  }
-
-  return new AIMessage({
-    id: message.id,
-    content: message.content,
-    name: message.name,
-    additional_kwargs: additionalKwargs,
-    response_metadata: message.response_metadata,
-    tool_calls: toolCalls,
-    invalid_tool_calls: message.invalid_tool_calls,
-    usage_metadata: message.usage_metadata,
-  });
 };
 
 const serializeToolResultContent = (content: unknown): string => {
@@ -251,16 +117,27 @@ const countMisplacedResults = (messages: readonly BaseMessage[]): number => {
   let misplacedResultCount = 0;
   for (let index = 0; index < messages.length; index++) {
     const message = messages[index];
-    if (!AIMessage.isInstance(message) || !message.tool_calls?.length) {
+    if (!AIMessage.isInstance(message)) {
       continue;
     }
-    for (let toolCallIndex = 0; toolCallIndex < message.tool_calls.length; toolCallIndex++) {
-      const toolCall = message.tool_calls[toolCallIndex];
-      const result = messages[index + toolCallIndex + 1];
-      if (!ToolMessage.isInstance(result) || result.tool_call_id !== toolCall.id) {
-        misplacedResultCount++;
+
+    const toolCalls = getValidToolCalls(message);
+    if (!toolCalls.length) {
+      continue;
+    }
+
+    const expectedToolCallIds = new Set(toolCalls.map((toolCall) => toolCall.id));
+    const contiguousResultIds = new Set<string>();
+    for (let offset = 1; offset <= toolCalls.length; offset++) {
+      const result = messages[index + offset];
+      if (!ToolMessage.isInstance(result)) {
+        break;
+      }
+      if (expectedToolCallIds.has(result.tool_call_id)) {
+        contiguousResultIds.add(result.tool_call_id);
       }
     }
+    misplacedResultCount += expectedToolCallIds.size - contiguousResultIds.size;
   }
   return misplacedResultCount;
 };
@@ -276,11 +153,9 @@ export const normalizeToolCallHistory = async (
 
   for (const message of messages) {
     if (AIMessage.isInstance(message)) {
-      for (const toolCall of message.tool_calls ?? []) {
+      for (const toolCall of getValidToolCalls(message)) {
         toolCallCount++;
-        if (toolCall.id) {
-          referencedToolCallIds.add(toolCall.id);
-        }
+        referencedToolCallIds.add(toolCall.id);
       }
     } else if (ToolMessage.isInstance(message)) {
       toolResultCount++;
@@ -295,9 +170,7 @@ export const normalizeToolCallHistory = async (
   const missingToolCallIds = Array.from(referencedToolCallIds).filter((id) => !toolResultsByCallId.has(id));
   const persistedResults = missingToolCallIds.length ? await options.loadToolResults(missingToolCallIds) : new Map();
   const normalized: BaseMessage[] = [];
-  const seenToolCallIds = new Set<string>();
   const nextToolResultIndexByCallId = new Map<string, number>();
-  let duplicateToolCallCount = 0;
   let restoredResultCount = 0;
   let syntheticResultCount = 0;
   let consumedExistingResultCount = 0;
@@ -306,43 +179,13 @@ export const normalizeToolCallHistory = async (
     if (ToolMessage.isInstance(message)) {
       continue;
     }
+
+    normalized.push(message);
     if (!AIMessage.isInstance(message)) {
-      normalized.push(message);
       continue;
     }
 
-    const toolCalls = message.tool_calls ?? [];
-    if (!toolCalls.length) {
-      const functionCallIds = message.additional_kwargs.__openai_function_call_ids__;
-      if (
-        Object.prototype.hasOwnProperty.call(message.additional_kwargs, 'tool_calls') ||
-        functionCallIds !== undefined
-      ) {
-        normalized.push(cloneAIMessageWithToolCalls(message, []));
-      } else {
-        normalized.push(message);
-      }
-      continue;
-    }
-
-    const retainedToolCalls = toolCalls.filter((toolCall) => {
-      if (!toolCall.id || seenToolCallIds.has(toolCall.id)) {
-        duplicateToolCallCount++;
-        return false;
-      }
-      seenToolCallIds.add(toolCall.id);
-      return true;
-    });
-
-    if (!retainedToolCalls.length) {
-      if (hasMessageContent(message.content)) {
-        normalized.push(cloneAIMessageWithToolCalls(message, []));
-      }
-      continue;
-    }
-
-    normalized.push(cloneAIMessageWithToolCalls(message, retainedToolCalls));
-    for (const toolCall of retainedToolCalls) {
+    for (const toolCall of getValidToolCalls(message)) {
       const existingResults = toolResultsByCallId.get(toolCall.id);
       const existingResultIndex = nextToolResultIndexByCallId.get(toolCall.id) ?? 0;
       const existingResult = existingResults?.[existingResultIndex];
@@ -365,14 +208,12 @@ export const normalizeToolCallHistory = async (
     }
   }
 
-  const totalToolResultCount = toolResultCount;
   const stats: NormalizationStats = {
     messageCount: messages.length,
     toolCallCount,
     missingResultCount: missingToolCallIds.length,
     misplacedResultCount: countMisplacedResults(messages),
-    duplicateToolCallCount,
-    orphanResultCount: totalToolResultCount - consumedExistingResultCount,
+    orphanResultCount: toolResultCount - consumedExistingResultCount,
     restoredResultCount,
     syntheticResultCount,
   };


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

When an AI response is aborted, `afterModel` and the stream abort listener can race while persisting the same LangChain AI message. The abort path previously saved a duplicate assistant message containing tool calls without creating the corresponding `aiToolMessages` or tool results. Strict providers such as Amazon Bedrock reject the resulting dangling `tool_use` history with HTTP 400.

### Description 

- Serializes `afterModel` and abort persistence with a transaction row lock on the current AI conversation.
- Reuses an already committed AI message by its LangChain message ID, including when `AfterAIMessageSaved` has not yet been consumed by the stream handler.
- Atomically persists an aborted assistant message, initializes all tool-call records, creates one interrupted tool result per unfinished call, and updates each record to `confirmed/error`.
- Preserves already confirmed successful tool results and makes repeated abort finalization idempotent.
- Retries after a tool-call unique constraint race so the losing transaction can reuse the committed message.
- Waits for abort finalization before ending the stream response.
- Adds integration coverage for multiple tool calls, concurrent persistence, committed-message fallback, idempotency, completed results, text-only aborts, unique conflicts, strict call/result pairing, and transaction rollback failures.

Potential risk: the new row lock serializes assistant-message persistence within one conversation. It does not add provider-boundary message-history normalization and does not rewrite existing dirty histories.

### Related issues


### Showcase
<!-- Including any screenshots of the changes. -->

Not applicable; this is a server-side persistence and transaction fix.

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Prevented Bedrock errors caused by aborted AI responses leaving tool calls without matching tool results. |
| 🇨🇳 Chinese | 修复 AI 响应中断后工具调用缺少对应结果而导致 Bedrock 请求报错的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | <!-- [Title](link) --> |
| 🇨🇳 Chinese | <!-- [标题](link) --> |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
