### PR TITLE
fix(ai): resolve document loader path in ESM

### DIFF
--- a/packages/core/ai/src/document-loader/index.ts
+++ b/packages/core/ai/src/document-loader/index.ts
@@ -8,8 +8,9 @@
  */
 
 import { Document } from '@langchain/core/documents';
-import { Worker } from 'node:worker_threads';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Worker } from 'node:worker_threads';
 
 export type DocumentLoaderWorkerOptions = {
   filePath: string;
@@ -21,8 +22,9 @@ export type DocumentLoaderWorkerOptions = {
 const DEFAULT_WORKER_TIMEOUT = 5 * 60 * 1000;
 
 export const loadByWorker = async (extname: string, options: DocumentLoaderWorkerOptions): Promise<Document[]> => {
-  const isTsRuntime = __filename.endsWith('.ts');
-  const workerPath = path.join(__dirname, `loader.worker.${isTsRuntime ? 'ts' : 'js'}`);
+  const moduleFilename = typeof __filename === 'string' ? __filename : fileURLToPath(import.meta.url);
+  const isTsRuntime = moduleFilename.endsWith('.ts');
+  const workerPath = path.join(path.dirname(moduleFilename), `loader.worker.${isTsRuntime ? 'ts' : 'js'}`);
   const worker = new Worker(workerPath, {
     execArgv: isTsRuntime ? ['--require', 'tsx/cjs'] : undefined,
   });


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Uploading a document to an AI knowledge base can fail with `__filename is not defined` when the document loader runs as an ES module.

### Description

Resolve the document loader module filename from `import.meta.url` in ESM runtimes while preserving the existing `__filename` path in CommonJS builds. Derive the worker directory from that resolved filename instead of relying directly on the CommonJS-only `__dirname` global.

Potential risk: low. The worker filename and TypeScript/CommonJS runtime selection remain unchanged after the module path is resolved.

Testing suggestions:

1. Upload a supported document to an AI knowledge base in the ESM runtime.
2. Verify the document loader worker starts and document segmentation completes.
3. Verify the CommonJS package build continues to load documents.

### Related issues

N/A

### Showcase

N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed document uploads to AI knowledge bases failing in ES module runtimes. |
| 🇨🇳 Chinese | 修复 ES Module 运行环境下 AI 知识库上传文档失败的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not required |
| 🇨🇳 Chinese | 不需要 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
