### PR TITLE
fix(plugin-data-source-manager): show record unique key in v2 editor

### DIFF
--- a/packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/CollectionsPage.tsx
+++ b/packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/CollectionsPage.tsx
@@ -1200,17 +1200,15 @@ function CollectionEditDrawer(props: {
         >
           <Checkbox>{t('Use simple pagination mode')}</Checkbox>
         </Form.Item>
-        {hasTemplateCapability(template, 'recordUniqueKey') ? (
-          <Form.Item
-            name="filterTargetKey"
-            label={t('Record unique key')}
-            extra={t(
-              'If a collection lacks a primary key, you must configure a unique record key to locate row records within a block, failure to configure this will prevent the creation of data blocks for the collection.',
-            )}
-          >
-            <Select mode="multiple" options={filterTargetKeyOptions} loading={fieldsRequest.loading} allowClear />
-          </Form.Item>
-        ) : null}
+        <Form.Item
+          name="filterTargetKey"
+          label={t('Record unique key')}
+          extra={t(
+            'If a collection lacks a primary key, you must configure a unique record key to locate row records within a block, failure to configure this will prevent the creation of data blocks for the collection.',
+          )}
+        >
+          <Select mode="multiple" options={filterTargetKeyOptions} loading={fieldsRequest.loading} allowClear />
+        </Form.Item>
       </Form>
     </DrawerFormLayout>
   );

--- a/packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/__tests__/CollectionsPageComponent.test.tsx
+++ b/packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/__tests__/CollectionsPageComponent.test.tsx
@@ -412,7 +412,7 @@ describe('CollectionsPage', () => {
     expect(externalDataSource.reload).toHaveBeenCalled();
   });
 
-  it('submits main collection edits through the collections resource', async () => {
+  it('shows and submits the record unique key when editing a main collection without template capability', async () => {
     renderCollectionsPage();
 
     const row = await screen.findByTestId('collection-row-orders');
@@ -420,6 +420,7 @@ describe('CollectionsPage', () => {
 
     const drawerContent = flowMocks.ctx.viewer.drawer.mock.calls[0][0].content();
     render(<App>{drawerContent}</App>);
+    expect(screen.getByText('t:Record unique key')).toBeInTheDocument();
     fireEvent.click(screen.getByText('t:Submit'));
 
     await waitFor(() =>
@@ -428,6 +429,7 @@ describe('CollectionsPage', () => {
         values: expect.objectContaining({
           title: '{{t("Orders")}}',
           category: ['1'],
+          filterTargetKey: ['id'],
           storage: 'archive',
         }),
       }),


### PR DESCRIPTION
<!--
First of all, thank you for your contribution!
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch.
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
The v2 collection editor did not show the record unique key setting for main data source collection templates unless they explicitly enabled the `recordUniqueKey` capability. This caused general collections to differ from the v1 editor, where the setting is always available during editing.

This PR targets `main` and is based on the latest `main` commit available when `task-6234` was created.

### Description
- Always show the existing record unique key field when editing a main data source collection in v2.
- Keep the capability-controlled behavior of collection creation unchanged.
- Continue using the existing `filterTargetKey` value, field options, and collection update API.
- Add a regression test proving that a general collection without the template capability still displays and submits its record unique key.

Risk is low because this is limited to the v2 edit form presentation and its existing update payload. It does not change database schemas, migrations, server APIs, ACL rules, or collection creation behavior. Reviewers can verify that editing a general collection displays "Record unique key" and preserves the selected key after submission.

Local verification:
- `yarn test packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/__tests__/CollectionsPageComponent.test.tsx --run --reporter=verbose` — 6 tests passed.
- `yarn test packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/__tests__/CollectionsPage.test.ts --run --reporter=verbose` — 11 tests passed.
- `yarn test packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/__tests__/RecordUniqueKey.test.tsx --run --reporter=verbose` — 2 tests passed.
- `yarn eslint --fix packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/CollectionsPage.tsx packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/__tests__/CollectionsPageComponent.test.tsx` — passed.
- `git diff --check` — passed.

Remote CI has not been claimed as passed; GitHub checks will run after PR creation.

### Related issues

Task: 6234

### Showcase

After this change, the v2 main data source collection editor displays the "Record unique key" selector for general collections, matching v1.

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the missing record unique key setting in the v2 collection editor. |
| 🇨🇳 Chinese | 修复 v2 数据表编辑器缺少记录唯一标识设置的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed; no documentation-facing behavior or API changed. |
| 🇨🇳 Chinese | 无需更新；未变更文档相关行为或 API。 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
