### PR TITLE
fix(plugin-collection-sql): restrict unsafe SQL queries

### DIFF
--- a/packages/plugins/@nocobase/plugin-collection-sql/src/server/__tests__/actions.test.ts
+++ b/packages/plugins/@nocobase/plugin-collection-sql/src/server/__tests__/actions.test.ts
@@ -45,7 +45,7 @@ describe('sql collection', () => {
 
     res = await agent.resource('sqlCollection').execute({
       values: {
-        sql: "select pg_read_file('/etc/passwd');",
+        sql: "select pg_read_file('/etc/passwd')",
       },
     });
     expect(res.status).toBe(400);
@@ -54,6 +54,10 @@ describe('sql collection', () => {
     for (const sql of [
       'select usename, passwd from pg_shadow',
       'select rolname, rolsuper from pg_roles',
+      'select * from pg_database',
+      'select * from pg_user',
+      'select * from pg_stat_all_tables',
+      'select * from pg_class',
       'select table_name from information_schema.tables',
       'select * from (select usename, passwd from pg_shadow) as passwords',
     ]) {
@@ -65,6 +69,14 @@ describe('sql collection', () => {
       expect(res.status).toBe(400);
       expect(res.body.errors[0].message).toMatch('SQL statements contain dangerous keywords');
     }
+
+    res = await agent.resource('sqlCollection').execute({
+      values: {
+        sql: 'select 1) as preview; delete from users; select * from (select 1',
+      },
+    });
+    expect(res.status).toBe(400);
+    expect(res.body.errors[0].message).toMatch('Only supports SELECT statements or WITH clauses');
   });
 
   it('sqlCollection:execute', async () => {
@@ -333,7 +345,7 @@ describe('sql collection', () => {
     const res = await agent.resource('collections').create({
       values: {
         name: 'sqlCollection',
-        sql: "select pg_read_file('/etc/passwd');",
+        sql: "select pg_read_file('/etc/passwd')",
         template: 'sql',
       },
     });

--- a/packages/plugins/@nocobase/plugin-collection-sql/src/server/__tests__/actions.test.ts
+++ b/packages/plugins/@nocobase/plugin-collection-sql/src/server/__tests__/actions.test.ts
@@ -45,7 +45,7 @@ describe('sql collection', () => {
 
     res = await agent.resource('sqlCollection').execute({
       values: {
-        sql: "select pg_read_file('/etc/passwd')",
+        sql: "select pg_read_file('/etc/passwd');",
       },
     });
     expect(res.status).toBe(400);
@@ -101,7 +101,7 @@ describe('sql collection', () => {
     const schema = process.env.DB_SCHEMA ? `${process.env.DB_SCHEMA}.` : ``;
     const res = await agent.resource('sqlCollection').execute({
       values: {
-        sql: `select * from ${schema}${db.queryInterface.quoteIdentifier('testSqlCollection')}`,
+        sql: `select * from ${schema}${db.queryInterface.quoteIdentifier('testSqlCollection')};\n`,
       },
     });
     expect(res.status).toBe(200);
@@ -251,7 +251,7 @@ describe('sql collection', () => {
       filterByTk: 'sqlCollection',
       values: {
         key: collection.key,
-        sql: "select pg_read_file('/etc/passwd')",
+        sql: "select pg_read_file('/etc/passwd');",
         name: 'sqlCollection',
         fields: [
           {

--- a/packages/plugins/@nocobase/plugin-collection-sql/src/server/__tests__/sql-collection.test.ts
+++ b/packages/plugins/@nocobase/plugin-collection-sql/src/server/__tests__/sql-collection.test.ts
@@ -28,7 +28,7 @@ test('sql-collection', async () => {
   });
   const collection = db.collectionFactory.createCollection<SQLCollection>({
     name: 'test',
-    sql: 'SELECT * FROM test;',
+    sql: 'SELECT * FROM test;\n',
   });
   expect(collection.isSql()).toBe(true);
   expect(collection.collectionSchema()).toBeUndefined();
@@ -37,6 +37,7 @@ test('sql-collection', async () => {
   expect(collection.options.underscored).toBe(false);
 
   collection.modelInit();
+  expect(collection.model.sql).toBe('SELECT * FROM test');
   // @ts-ignore
   expect(collection.model._schema).toBeUndefined();
 });

--- a/packages/plugins/@nocobase/plugin-collection-sql/src/server/sql-collection/sql-collection.ts
+++ b/packages/plugins/@nocobase/plugin-collection-sql/src/server/sql-collection/sql-collection.ts
@@ -61,7 +61,8 @@ export class SQLCollection extends Collection {
       model.removeAttribute('id');
     }
 
-    model.sql = sql?.endsWith(';') ? sql.slice(0, -1) : sql;
+    const normalizedSQL = sql?.trim();
+    model.sql = normalizedSQL?.endsWith(';') ? normalizedSQL.slice(0, -1) : normalizedSQL;
     model.database = this.context.database;
     model.collection = this;
 

--- a/packages/plugins/@nocobase/plugin-collection-sql/src/server/utils.ts
+++ b/packages/plugins/@nocobase/plugin-collection-sql/src/server/utils.ts
@@ -10,24 +10,10 @@
 export const checkSQL = (sql: string) => {
   const dangerKeywords = [
     // PostgreSQL
-    'pg_read_file',
-    'pg_read_binary_file',
-    'pg_stat_file',
-    'pg_ls_dir',
-    'pg_logdir_ls',
-    'pg_terminate_backend',
-    'pg_cancel_backend',
+    'pg_',
     'current_setting',
     'set_config',
-    'pg_reload_conf',
-    'pg_sleep',
     'generate_series',
-    'pg_catalog',
-    'pg_shadow',
-    'pg_authid',
-    'pg_auth_members',
-    'pg_roles',
-    'pg_stat_activity',
     'information_schema',
 
     // MySQL
@@ -40,7 +26,10 @@ export const checkSQL = (sql: string) => {
     'sqlite3_load_extension',
     'load_extension',
   ];
-  sql = sql.trim().split(';').shift() || '';
+  sql = sql.trim();
+  if (sql.includes(';')) {
+    throw new Error('Only supports SELECT statements or WITH clauses');
+  }
   if (!/^select/i.test(sql) && !/^with([\s\S]+)select([\s\S]+)/i.test(sql)) {
     throw new Error('Only supports SELECT statements or WITH clauses');
   }

--- a/packages/plugins/@nocobase/plugin-collection-sql/src/server/utils.ts
+++ b/packages/plugins/@nocobase/plugin-collection-sql/src/server/utils.ts
@@ -27,6 +27,9 @@ export const checkSQL = (sql: string) => {
     'load_extension',
   ];
   sql = sql.trim();
+  if (sql.endsWith(';')) {
+    sql = sql.slice(0, -1);
+  }
   if (sql.includes(';')) {
     throw new Error('Only supports SELECT statements or WITH clauses');
   }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Prevent SQL collections from exposing PostgreSQL system metadata and from validating only the first statement while executing the complete input.

### Description 
Restricts PostgreSQL system objects through the common `pg_` prefix and continues blocking `information_schema`. After allowing one optional trailing semicolon, SQL input containing another semicolon is rejected so only one statement can reach execution.

Adds regression coverage for common PostgreSQL system views, trailing-semicolon normalization, and a multi-statement escape attempt. The focused server tests pass with all 7 cases.

SQL collection statements with a trailing semicolon remain supported.

### Related issues

### Showcase
Not applicable; this is a server-side validation change.

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Restricted SQL collections from querying PostgreSQL system objects or executing multiple statements |
| 🇨🇳 Chinese | 限制 SQL 数据表查询 PostgreSQL 系统对象或执行多条语句 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
