### PR TITLE
fix(plugin-field-markdown-vditor): default detail preview to html

### DIFF
--- a/packages/plugins/@nocobase/plugin-field-markdown-vditor/src/client-v2/__tests__/VditorFieldModels.test.tsx
+++ b/packages/plugins/@nocobase/plugin-field-markdown-vditor/src/client-v2/__tests__/VditorFieldModels.test.tsx
@@ -114,10 +114,48 @@ describe('VditorFieldModel', () => {
 });
 
 describe('DisplayVditorFieldModel', () => {
+  it('uses HTML as the default render mode', () => {
+    const flow = (
+      DisplayVditorFieldModel as unknown as { registerFlow: ReturnType<typeof vi.fn> }
+    ).registerFlow.mock.calls
+      .map(([config]) => config)
+      .find((config) => config.key === 'markdownVditorSettings');
+
+    expect(flow.steps.renderMode.defaultParams).toEqual({ textOnly: false });
+  });
+
   it('renders nothing for empty values', () => {
     const model = Object.create(DisplayVditorFieldModel.prototype) as DisplayVditorFieldModel;
 
     expect(model.renderComponent('')).toBeNull();
+  });
+
+  it('renders HTML when no render mode has been configured', async () => {
+    const markdownRender = vi.fn((value: string, props: Record<string, unknown>) => (
+      <span data-testid="rendered" data-text-only={props.textOnly ? 'yes' : 'no'}>
+        {value}
+      </span>
+    ));
+    const model = Object.create(DisplayVditorFieldModel.prototype) as DisplayVditorFieldModel & {
+      props: Record<string, unknown>;
+      context: Record<string, unknown>;
+    };
+    model.props = {};
+    model.context = {
+      markdownVditor: {
+        render: markdownRender,
+      },
+      liquid: {},
+      t: (value: string) => value,
+    };
+
+    render(model.renderComponent('![image](image.png)'));
+
+    await waitFor(() => expect(screen.getByTestId('rendered')).toHaveAttribute('data-text-only', 'no'));
+    expect(markdownRender).toHaveBeenCalledWith('![image](image.png)', {
+      ellipsis: false,
+      textOnly: false,
+    });
   });
 
   it('renders translated markdown through the display runtime', async () => {

--- a/packages/plugins/@nocobase/plugin-field-markdown-vditor/src/client-v2/models/DisplayVditorFieldModel.tsx
+++ b/packages/plugins/@nocobase/plugin-field-markdown-vditor/src/client-v2/models/DisplayVditorFieldModel.tsx
@@ -27,7 +27,7 @@ const Display = ({ value, markdown, liquid, t, textOnly, ctx, overflowMode, pars
         setContent(`<pre style="color:red;"> 渲染错误: ${err.message}</pre>`);
       }
     })();
-  }, [value, textOnly, overflowMode]);
+  }, [ctx, liquid, markdown, overflowMode, parseLiquid, t, textOnly, value]);
 
   return content;
 };
@@ -36,7 +36,7 @@ export class DisplayVditorFieldModel extends DisplayTitleFieldModel {
   public renderComponent(value) {
     if (!value) return null;
     const { markdownVditor, markdown, liquid, t } = this.context;
-    const { textOnly, overflowMode } = this.props;
+    const { textOnly = false, overflowMode } = this.props;
     return (
       <Display
         value={value}
@@ -62,6 +62,9 @@ DisplayVditorFieldModel.registerFlow({
   steps: {
     renderMode: {
       use: 'renderMode',
+      defaultParams: {
+        textOnly: false,
+      },
     },
   },
 });


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Vditor fields in detail views defaulted to text-only rendering. This prevented Markdown images and other HTML-rendered content from being displayed unless users manually changed the render mode.

### Description
- Change the default render mode of Vditor fields in detail views from text-only to HTML.
- Keep the existing render-mode setting so users can still explicitly select text-only rendering.
- Limit the change to Vditor detail fields without changing the defaults for other Markdown or rich-text fields.
- Add tests covering the flow default and the fallback behavior when no render mode has been configured.

Potential risk: existing Vditor detail fields without an explicitly saved render mode will now render Markdown as HTML. Fields explicitly configured as text-only remain unchanged.

Testing suggestions:
1. Add a Vditor field to a detail block without configuring its render mode.
2. Save Markdown containing an image and verify that the image is displayed.
3. Switch the field to text-only mode and verify that it still renders as plain text.

### Related issues

N/A

### Showcase

N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Vditor detail fields to use HTML preview by default so Markdown images can be displayed. |
| 🇨🇳 Chinese | 修复 Vditor 详情字段默认使用纯文本预览导致 Markdown 图片无法展示的问题，默认改为 HTML 预览。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
