### PR TITLE
fix(plugin-workflow-javascript): avoid aborting valid claimed jobs

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow-javascript/src/server/TaskConsumer.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-javascript/src/server/TaskConsumer.ts
@@ -60,6 +60,10 @@ function getErrorMessage(error: unknown) {
   return error instanceof Error ? error.message : String(error);
 }
 
+function isSameClaim(left: Date | null | undefined, right: Date | null | undefined) {
+  return left?.getTime() === right?.getTime();
+}
+
 function createJobAbortController(
   workflowPlugin: WorkflowPlugin,
   runningJobs: RunningJobs,
@@ -351,8 +355,19 @@ export class TaskConsumer {
           },
         },
       )
-        .then(([affected]) => {
-          if (!affected) {
+        .then(async ([affected]) => {
+          if (affected) {
+            return;
+          }
+
+          const currentJob = (await JobModel.findByPk(job.id, {
+            attributes: ['status', 'startedAt'],
+          })) as JobModel | null;
+          if (
+            !currentJob ||
+            currentJob.status !== JOB_STATUS.PENDING ||
+            !isSameClaim(currentJob.startedAt, job.startedAt)
+          ) {
             abort();
           }
         })

--- a/packages/plugins/@nocobase/plugin-workflow-javascript/src/server/__tests__/instruction.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-javascript/src/server/__tests__/instruction.test.ts
@@ -284,6 +284,38 @@ describe('workflow > instructions > script', () => {
       }
     });
 
+    it('should continue an async workflow when a JavaScript node times out', async () => {
+      await workflow.update({ sync: false });
+      await workflow.createNode({
+        type: SCRIPT_INSTRUCTION_TYPE,
+        config: {
+          content: `
+            const { setTimeout } = require('node:timers');
+            await new Promise((resolve) => setTimeout(resolve, 1000));
+          `,
+          timeout: 100,
+          continue: true,
+        },
+      });
+
+      await PostRepo.create({ values: { title: 'post' } });
+
+      let execution;
+      let job;
+      for (let i = 0; i < 30; i++) {
+        [execution] = await workflow.getExecutions();
+        [job] = execution ? await execution.getJobs() : [];
+        if (execution?.status === EXECUTION_STATUS.RESOLVED && job?.status === JOB_STATUS.RESOLVED) {
+          break;
+        }
+        await sleep(50);
+      }
+
+      expect(execution?.status).toBe(EXECUTION_STATUS.RESOLVED);
+      expect(job?.status).toBe(JOB_STATUS.RESOLVED);
+      expect(job?.result).toBe('Script execution timed out after 100ms');
+    });
+
     it('should discard a worker result that arrives after manual cancellation', async () => {
       let resolveRun: ((result: { status: number; result: string }) => void) | undefined;
       let workerSignal: AbortSignal | undefined;

--- a/packages/plugins/@nocobase/plugin-workflow-javascript/src/server/__tests__/worker-queue.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-javascript/src/server/__tests__/worker-queue.test.ts
@@ -326,12 +326,14 @@ describe('JavaScript task heartbeat', () => {
     vi.useRealTimers();
   });
 
-  it('aborts the local Worker when the claimed job is no longer pending', async () => {
+  it('keeps the local Worker running when the heartbeat update reports no change for the same claim', async () => {
     vi.useFakeTimers();
     const update = vi.fn().mockResolvedValue([0]);
+    const startedAt = new Date();
+    const findByPk = vi.fn().mockResolvedValue({ status: JOB_STATUS.PENDING, startedAt });
     const workflowPlugin = {
       db: {
-        getModel: () => ({ update }),
+        getModel: () => ({ update, findByPk }),
       },
       getLogger: () => ({ error: vi.fn() }),
     } as unknown as WorkflowPlugin;
@@ -339,7 +341,31 @@ describe('JavaScript task heartbeat', () => {
       startClaimHeartbeat(job: { id: string; startedAt: Date }, abort: () => void): () => Promise<void>;
     };
     const abort = vi.fn();
-    const stop = consumer.startClaimHeartbeat({ id: 'job-3', startedAt: new Date() }, abort);
+    const stop = consumer.startClaimHeartbeat({ id: 'job-3', startedAt }, abort);
+
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    expect(findByPk).toHaveBeenCalledWith('job-3', { attributes: ['status', 'startedAt'] });
+    expect(abort).not.toHaveBeenCalled();
+    await stop();
+  });
+
+  it('aborts the local Worker when the claimed job is no longer pending', async () => {
+    vi.useFakeTimers();
+    const update = vi.fn().mockResolvedValue([0]);
+    const startedAt = new Date();
+    const findByPk = vi.fn().mockResolvedValue({ status: JOB_STATUS.ABORTED, startedAt });
+    const workflowPlugin = {
+      db: {
+        getModel: () => ({ update, findByPk }),
+      },
+      getLogger: () => ({ error: vi.fn() }),
+    } as unknown as WorkflowPlugin;
+    const consumer = new TaskConsumer(workflowPlugin, new RunningJobs()) as unknown as {
+      startClaimHeartbeat(job: { id: string; startedAt: Date }, abort: () => void): () => Promise<void>;
+    };
+    const abort = vi.fn();
+    const stop = consumer.startClaimHeartbeat({ id: 'job-4', startedAt }, abort);
 
     await vi.advanceTimersByTimeAsync(30_000);
 


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

An asynchronous JavaScript workflow node could be incorrectly marked as `ABORTED` when its configured timeout coincided with the 30-second claim heartbeat. A heartbeat update reporting zero affected rows immediately aborted the local Worker, even when the job was still pending and owned by the same claim. This bypassed the node's "Continue when exception thrown" behavior.

### Description

- Re-check the persisted job when a claim heartbeat update reports zero affected rows.
- Abort the local Worker only when the job was deleted, is no longer pending, or its `startedAt` indicates that ownership changed.
- Keep running the Worker when the persisted job still represents the same active claim.
- Add regression coverage for heartbeat ownership checks and for an asynchronous JavaScript node that times out with `continue` enabled.

Manual cancellation and workflow-level timeouts continue to produce `ABORTED` executions. The additional database read only occurs when a heartbeat update reports zero affected rows.

Testing suggestions:

- Run a JavaScript node with a 30-second timeout and "Continue when exception thrown" enabled, and verify that a timeout resolves the node with the timeout error instead of aborting the workflow.
- Verify that manually cancelling a running JavaScript node still aborts its Worker and workflow execution.

### Related issues

### Showcase

Not applicable (server-side fix).

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed an issue where a timed-out JavaScript workflow node could incorrectly abort the workflow instead of respecting "Continue when exception thrown". |
| 🇨🇳 Chinese | 修复 JavaScript 工作流节点超时时可能错误中止工作流、未遵循“出现异常时继续执行”配置的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | 不需要 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
