### PR TITLE
fix(plugin-kanban): show newly created records

### DIFF
--- a/packages/plugins/@nocobase/plugin-kanban/src/client/KanbanBlockProvider.tsx
+++ b/packages/plugins/@nocobase/plugin-kanban/src/client/KanbanBlockProvider.tsx
@@ -147,7 +147,7 @@ export const useKanbanBlockProps = () => {
     }
     field.value = data;
     setDataSource(field.value);
-  }, [ctx?.service?.loading, options]);
+  }, [ctx?.service?.data?.data, ctx?.service?.loading, options]);
 
   const disableCardDrag = useDisableCardDrag();
 


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Fixes #10454.

When a new record is created from the Kanban block, the newly created record is not immediately visible on the Kanban board.

The issue requires the Kanban block to update its displayed records correctly after a new record is created.

### Description

This PR updates the Kanban block's record handling to ensure that newly created records are properly reflected in the Kanban board.

#### Key changes
- Updated `KanbanBlockProvider.tsx`.
- Fixed the handling of newly created records in the Kanban block.
- Kept the change scoped to the Kanban plugin.

#### Potential risks
- The change affects the Kanban block's record creation/data update behavior.
- Existing Kanban record loading and rendering behavior should remain unchanged.

#### Testing suggestions
The change has **not been tested yet**.

Suggested testing:
1. Open a page containing a Kanban block.
2. Create a new record from the Kanban block.
3. Verify that the newly created record appears immediately.
4. Verify that existing records continue to display correctly.
5. Refresh the page and verify that records are displayed correctly.

### Related issues

Closes #10454

### Showcase

<!-- Not provided because the change has not been tested yet. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed an issue where newly created records were not immediately visible in the Kanban block. |
| 🇨🇳 Chinese | 修复了看板中新创建的记录无法立即显示的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | 不需要 |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary