### PR TITLE
fix(server): prevent synchronized app starts outside deployment environments

### DIFF
--- a/packages/core/server/src/__tests__/app-supervisor/boot-main-app.test.ts
+++ b/packages/core/server/src/__tests__/app-supervisor/boot-main-app.test.ts
@@ -95,4 +95,41 @@ describe('AppSupervisor bootMainApp behavior in worker mode', () => {
     await mainApp.emitAsync('afterDestroy', mainApp);
     expect(unregisterEnvironmentSpy).toHaveBeenCalled();
   });
+
+  it.each([
+    { environments: ['B'], environmentName: 'A', shouldStart: false },
+    { environments: [], environmentName: 'A', shouldStart: false },
+    { environments: ['B'], environmentName: undefined, shouldStart: false },
+    { environments: ['A'], environmentName: 'A', shouldStart: true },
+    { environments: ['A', 'B'], environmentName: 'A', shouldStart: true },
+    { environments: undefined, environmentName: undefined, shouldStart: true },
+  ])(
+    'handles app:started with environments=$environments in $environmentName (shouldStart=$shouldStart)',
+    async ({ environments, environmentName, shouldStart }) => {
+      process.env.WORKER_MODE = '!';
+      vi.spyOn(supervisor, 'environmentName', 'get').mockReturnValue(environmentName);
+
+      const mainApp = supervisor.bootMainApp({});
+      await mainApp.emitAsync('afterStart', mainApp);
+      const subscribe = vi.mocked(mainApp.syncMessageManager.subscribe);
+      const callback = subscribe.mock.calls.find(([channel]) => channel === 'app_supervisor:sync')?.[1];
+      expect(callback).toBeDefined();
+
+      const appModel = { name: 'sub-app', environments, options: {} };
+      vi.spyOn(supervisor, 'hasApp').mockReturnValue(false);
+      vi.spyOn(supervisor, 'getAppModel').mockResolvedValue(appModel);
+      const registerApp = vi.spyOn(supervisor, 'registerApp').mockReturnValue(mainApp);
+      const runCommand = vi.spyOn(mainApp, 'runCommand').mockResolvedValue(undefined);
+
+      await callback({ type: 'app:started', appName: appModel.name });
+
+      if (shouldStart) {
+        expect(registerApp).toHaveBeenCalledWith({ appModel, mainApp });
+        expect(runCommand).toHaveBeenCalledWith('start', '--quickstart');
+      } else {
+        expect(registerApp).not.toHaveBeenCalled();
+        expect(runCommand).not.toHaveBeenCalled();
+      }
+    },
+  );
 });

--- a/packages/core/server/src/app-supervisor/index.ts
+++ b/packages/core/server/src/app-supervisor/index.ts
@@ -483,6 +483,9 @@ export class AppSupervisor extends EventEmitter implements AsyncEmitter {
             if (!appOptions) {
               return;
             }
+            if (appModel.environments && !appModel.environments.includes(this.environmentName)) {
+              return;
+            }
             const newApp = this.registerApp({ appModel, mainApp: app });
             newApp.runCommand('start', '--quickstart');
           }


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

When deployment environments share the main application's sync channel, starting an app assigned only to B also starts it in A and records an incorrect running status for A.

### Description

Check application deployment environments before registering an app in the `app:started` handler, matching `initApp()`. Reject non-matching or empty deployment lists while preserving legacy applications without the field. Shared channels and stop/remove behavior are unchanged.

Validation: all 9 tests in `boot-main-app.test.ts` pass, including 6 new cases covering environment mismatch, empty lists, missing environment names, allowed single/multiple environments, and legacy applications. ESLint and diff checks pass.

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed applications unexpectedly starting in environments where they were not deployed |
| 🇨🇳 Chinese | 修复应用在未部署的环境中被意外启动的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | <!-- [Title](link) --> |
| 🇨🇳 Chinese | <!-- [标题](link) --> |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
