### PR TITLE
fix: preserve bigint user IDs without precision loss

### DIFF
--- a/packages/plugins/@nocobase/plugin-notification-in-app-message/src/server/InAppNotificationChannel.ts
+++ b/packages/plugins/@nocobase/plugin-notification-in-app-message/src/server/InAppNotificationChannel.ts
@@ -75,7 +75,7 @@ export default class InAppNotificationChannel extends BaseNotificationChannel {
   }
 
   private async persistMessagesInBatches(options: {
-    userIds: number[];
+    userIds: Array<number | string>;
     title: string;
     content: string;
     channelName: string;
@@ -151,14 +151,14 @@ export default class InAppNotificationChannel extends BaseNotificationChannel {
   send: SendFnType<InAppMessageFormValues> = async (params) => {
     const startedAt = Date.now();
     const { channel, message, receivers, transaction } = params;
-    let userIds: number[];
+    let userIds: Array<number | string>;
     const { content, title, options = {} } = message;
     const userRepo = this.app.db.getRepository('users');
     const resolveReceiversStartedAt = Date.now();
     if (receivers?.type === 'userId') {
       userIds = receivers.value;
     } else {
-      userIds = (await parseUserSelectionConf(message.receivers, userRepo, { transaction })).map((id) => Number(id));
+      userIds = await parseUserSelectionConf(message.receivers, userRepo, { transaction });
     }
     const resolveReceiversMs = Date.now() - resolveReceiversStartedAt;
 

--- a/packages/plugins/@nocobase/plugin-notification-in-app-message/src/server/__tests__/server.test.ts
+++ b/packages/plugins/@nocobase/plugin-notification-in-app-message/src/server/__tests__/server.test.ts
@@ -501,6 +501,40 @@ describe('inapp message channels', () => {
     });
   });
 
+  test('send should preserve BIGINT user IDs resolved from receiver configuration', async () => {
+    const bulkCreate = vi.fn().mockResolvedValue(undefined);
+    const userIds = ['9007199254740992', '9007199254740993'];
+    const channel = new InAppNotificationChannel({
+      db: {
+        getRepository: vi.fn().mockReturnValue({}),
+        getModel: vi.fn().mockReturnValue({ bulkCreate }),
+      },
+      emit: vi.fn(),
+      logger: {
+        error: vi.fn(),
+        warn: vi.fn(),
+      },
+    } as any);
+
+    await channel.send({
+      channel: {
+        name: 'in-app',
+        notificationType: 'in-app-message',
+        options: {},
+      },
+      message: {
+        title: 'test title',
+        content: 'test content',
+        receivers: userIds,
+      } as any,
+      transaction: {
+        afterCommit: vi.fn(),
+      } as any,
+    });
+
+    expect(bulkCreate.mock.calls[0][0].map((message) => message.userId)).toEqual(userIds);
+  });
+
   test('send should split large receiver sets into bulk batches', async () => {
     const bulkCreate = vi.fn().mockResolvedValue(undefined);
     const emit = vi.fn();

--- a/packages/plugins/@nocobase/plugin-notification-manager/src/server/types.ts
+++ b/packages/plugins/@nocobase/plugin-notification-manager/src/server/types.ts
@@ -42,7 +42,7 @@ export type SendFnType<Message> = (args: {
 }) => Promise<{ message: Message; status: 'success' | 'failure'; reason?: string }>;
 
 export type ReceiversOptions =
-  | { value: number[]; type: 'userId' }
+  | { value: Array<number | string>; type: 'userId' }
   | { value: any; type: 'channel-self-defined'; channelType: string };
 export interface SendOptions extends Transactionable {
   channelName: string;
@@ -55,7 +55,7 @@ export interface SendOptions extends Transactionable {
 export type NotificationQueueMessage = Omit<SendOptions, 'transaction'>;
 
 export interface SendUserOptions extends Transactionable {
-  userIds: number[];
+  userIds: Array<number | string>;
   channels: string[];
   message: Record<string, any>;
   data?: Record<string, any>;

--- a/packages/plugins/@nocobase/plugin-workflow-cc/src/server/plugin.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-cc/src/server/plugin.ts
@@ -16,7 +16,7 @@ import { TASK_STATUS, TASK_TYPE_CC } from '../common/constants';
 import { initActions } from './actions';
 
 type GroupedTaskCount = {
-  userId: number;
+  userId: TaskStatsRow['userId'];
   workflowId: number;
   count: number | string;
 };
@@ -33,7 +33,7 @@ export class PluginWorkflowCCServer extends Plugin {
   }
 
   private async collectCcTaskStats(options: {
-    userIds?: number[];
+    userIds?: Array<TaskStatsRow['userId']>;
     workflowKeys?: string[];
     transaction?: Transaction;
   }): Promise<TaskStatsRow[]> {
@@ -131,7 +131,7 @@ export class PluginWorkflowCCServer extends Plugin {
   }
 
   onRecordSave = async (record: Model, { transaction }) => {
-    const userId = record.get('userId') as number | undefined;
+    const userId = record.get('userId') as TaskStatsRow['userId'] | undefined;
     const workflowId = record.get('workflowId') as number | undefined;
     if (!userId || !workflowId) {
       return;

--- a/packages/plugins/@nocobase/plugin-workflow-manual/src/server/Plugin.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-manual/src/server/Plugin.ts
@@ -17,7 +17,7 @@ import ManualInstruction from './ManualInstruction';
 import { TASK_TYPE_MANUAL, TASK_STATUS } from '../common/constants';
 
 type GroupedTaskCount = {
-  userId: number;
+  userId: TaskStatsRow['userId'];
   workflowId: number;
   count: number | string;
 };
@@ -49,7 +49,7 @@ export default class extends Plugin {
   }
 
   private async collectManualTaskStats(options: {
-    userIds?: number[];
+    userIds?: Array<TaskStatsRow['userId']>;
     workflowKeys?: string[];
     transaction?: Transaction;
   }): Promise<TaskStatsRow[]> {
@@ -124,7 +124,11 @@ export default class extends Plugin {
     return Array.from(statsMap.values());
   }
 
-  private async updateManualWorkflowTaskStats(userId: number, workflowKey: string, transaction?: Transaction) {
+  private async updateManualWorkflowTaskStats(
+    userId: TaskStatsRow['userId'],
+    workflowKey: string,
+    transaction?: Transaction,
+  ) {
     const workflowPlugin = this.app.pm.get(WorkflowPlugin) as WorkflowPlugin;
     const [row] = await this.collectManualTaskStats({
       userIds: [userId],
@@ -159,7 +163,7 @@ export default class extends Plugin {
     return workflow?.key as string | undefined;
   }
 
-  private async updateManualTaskStats(userIds: number[], transaction?: Transaction) {
+  private async updateManualTaskStats(userIds: Array<TaskStatsRow['userId']>, transaction?: Transaction) {
     if (!userIds.length) {
       return;
     }
@@ -182,7 +186,7 @@ export default class extends Plugin {
   }
 
   onTaskSave = async (task: Model, { transaction }) => {
-    const userId = task.get('userId') as number | undefined;
+    const userId = task.get('userId') as TaskStatsRow['userId'] | undefined;
     const workflowId = task.get('workflowId') as number | undefined;
     if (!userId || !workflowId) {
       return;
@@ -253,7 +257,10 @@ export default class extends Plugin {
       },
       transaction,
     });
-    await this.updateManualTaskStats(rows.map((row) => row.get('userId') as number).filter(Boolean), transaction);
+    await this.updateManualTaskStats(
+      rows.map((row) => row.get('userId') as TaskStatsRow['userId']).filter(Boolean),
+      transaction,
+    );
   };
 
   async load() {

--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/UsersSelect.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/UsersSelect.tsx
@@ -95,12 +95,11 @@ function UserPickerInput(props: {
 }) {
   const { disabled, onChange, value } = props;
   const ctx = useFlowContext();
-  const normalizedValue = typeof value === 'string' && /^\d+$/.test(value) ? Number(value) : value;
 
   return (
     <RemoteSelect<UserOption, UserOption[], number | string>
       disabled={disabled}
-      value={normalizedValue}
+      value={value}
       onChange={(next) => onChange?.(next == null ? '' : next)}
       request={async () => {
         const response = await ctx.api.resource('users').list();

--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/UsersSelect.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/UsersSelect.tsx
@@ -95,11 +95,13 @@ function UserPickerInput(props: {
 }) {
   const { disabled, onChange, value } = props;
   const ctx = useFlowContext();
+  const numericValue = typeof value === 'string' && /^\d+$/.test(value) ? Number(value) : NaN;
+  const normalizedValue = Number.isSafeInteger(numericValue) ? numericValue : value;
 
   return (
     <RemoteSelect<UserOption, UserOption[], number | string>
       disabled={disabled}
-      value={value}
+      value={normalizedValue}
       onChange={(next) => onChange?.(next == null ? '' : next)}
       request={async () => {
         const response = await ctx.api.resource('users').list();

--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/UsersSelect.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/UsersSelect.tsx
@@ -97,12 +97,19 @@ function UserPickerInput(props: {
   const ctx = useFlowContext();
   const numericValue = typeof value === 'string' && /^\d+$/.test(value) ? Number(value) : NaN;
   const normalizedValue = Number.isSafeInteger(numericValue) ? numericValue : value;
+  const handleChange = (next: number | string | null | undefined) => {
+    if (next == null) {
+      onChange?.('');
+      return;
+    }
+    onChange?.(Number.isSafeInteger(numericValue) && next === numericValue ? value : next);
+  };
 
   return (
     <RemoteSelect<UserOption, UserOption[], number | string>
       disabled={disabled}
       value={normalizedValue}
-      onChange={(next) => onChange?.(next == null ? '' : next)}
+      onChange={handleChange}
       request={async () => {
         const response = await ctx.api.resource('users').list();
         const payload = (response as UsersListResponse)?.data?.data;

--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/__tests__/UsersSelect.test.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/__tests__/UsersSelect.test.tsx
@@ -101,4 +101,12 @@ describe('UsersSelect', () => {
       expect.objectContaining({ collection: 'users', transformVariableOptions }),
     );
   });
+
+  it('preserves BIGINT user IDs as strings', () => {
+    const userId = '9007199254740993';
+
+    render(<UsersSelect value={userId} />);
+
+    expect(holder.remoteSelect).toHaveBeenCalledWith(expect.objectContaining({ value: userId }), expect.anything());
+  });
 });

--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/__tests__/UsersSelect.test.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/__tests__/UsersSelect.test.tsx
@@ -109,4 +109,10 @@ describe('UsersSelect', () => {
 
     expect(holder.remoteSelect).toHaveBeenCalledWith(expect.objectContaining({ value: userId }), expect.anything());
   });
+
+  it('normalizes safe integer user IDs for numeric select options', () => {
+    render(<UsersSelect value="1" />);
+
+    expect(holder.remoteSelect).toHaveBeenCalledWith(expect.objectContaining({ value: 1 }), expect.anything());
+  });
 });

--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/__tests__/UsersSelect.test.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/__tests__/UsersSelect.test.tsx
@@ -111,8 +111,13 @@ describe('UsersSelect', () => {
   });
 
   it('normalizes safe integer user IDs for numeric select options', () => {
-    render(<UsersSelect value="1" />);
+    const onChange = vi.fn();
+    render(<UsersSelect value="1" onChange={onChange} />);
 
     expect(holder.remoteSelect).toHaveBeenCalledWith(expect.objectContaining({ value: 1 }), expect.anything());
+
+    const remoteSelectProps = holder.remoteSelect.mock.calls[0][0];
+    remoteSelectProps.onChange(1);
+    expect(onChange).toHaveBeenCalledWith('1');
   });
 });

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/Plugin.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/Plugin.ts
@@ -51,14 +51,14 @@ type ID = number | string;
 type TransactionWithSequelize = Transaction & { sequelize?: Sequelize };
 type TaskStats = { pending: number; all: number };
 export type TaskStatsRow = {
-  userId: number;
+  userId: ID;
   workflowKey: string;
   type: string;
   pending: number;
   all: number;
 };
 export type RepairTaskStatsOptions = {
-  userIds?: number[];
+  userIds?: ID[];
   workflowKeys?: string[];
   types?: string[];
   transaction?: Transaction;
@@ -766,7 +766,7 @@ export default class PluginWorkflowServer extends Plugin {
     );
   }
 
-  private sendTaskWorkflowStatsUpdated(userId: number, workflowKey: string, stats: TaskStats) {
+  private sendTaskWorkflowStatsUpdated(userId: ID, workflowKey: string, stats: TaskStats) {
     if (!userId) {
       return;
     }
@@ -865,6 +865,11 @@ export default class PluginWorkflowServer extends Plugin {
 
       const typePairs = new Set<string>();
       const workflowPairs = new Set<string>();
+      const getUserIdFromPair = (pair: string): ID => {
+        const userId = pair.slice(0, pair.indexOf('\0'));
+        const numericUserId = Number(userId);
+        return Number.isSafeInteger(numericUserId) ? numericUserId : userId;
+      };
       if (options.userIds?.length) {
         for (const userId of options.userIds) {
           for (const [type] of providers) {
@@ -883,7 +888,7 @@ export default class PluginWorkflowServer extends Plugin {
         workflowPairs.add(`${row.userId}\0${row.workflowKey}`);
       }
 
-      const affectedUserIds = Array.from(typePairs, (pair) => Number(pair.slice(0, pair.indexOf('\0'))));
+      const affectedUserIds = Array.from(typePairs, getUserIdFromPair);
       const affectedTypes = Array.from(typePairs, (pair) => pair.slice(pair.indexOf('\0') + 1));
       const categorizedRows = typePairs.size
         ? ((await TaskStatsModel.findAll({
@@ -906,7 +911,7 @@ export default class PluginWorkflowServer extends Plugin {
       const categorizedValues = Array.from(typePairs, (pair) => {
         const separatorIndex = pair.indexOf('\0');
         return {
-          userId: Number(pair.slice(0, separatorIndex)),
+          userId: getUserIdFromPair(pair),
           type: pair.slice(separatorIndex + 1),
           stats: categorizedMap.get(pair) ?? { pending: 0, all: 0 },
         };
@@ -944,7 +949,7 @@ export default class PluginWorkflowServer extends Plugin {
         });
       }
 
-      const affectedWorkflowUserIds = Array.from(workflowPairs, (pair) => Number(pair.slice(0, pair.indexOf('\0'))));
+      const affectedWorkflowUserIds = Array.from(workflowPairs, getUserIdFromPair);
       const affectedWorkflowKeys = Array.from(workflowPairs, (pair) => pair.slice(pair.indexOf('\0') + 1));
       const workflowRows = workflowPairs.size
         ? ((await TaskStatsModel.findAll({
@@ -971,7 +976,7 @@ export default class PluginWorkflowServer extends Plugin {
       );
       for (const pair of workflowPairs) {
         const separatorIndex = pair.indexOf('\0');
-        const userId = Number(pair.slice(0, separatorIndex));
+        const userId = getUserIdFromPair(pair);
         const workflowKey = pair.slice(separatorIndex + 1);
         this.sendTaskWorkflowStatsUpdated(userId, workflowKey, workflowMap.get(pair) ?? { pending: 0, all: 0 });
       }

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/Plugin.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/Plugin.ts
@@ -720,7 +720,7 @@ export default class PluginWorkflowServer extends Plugin {
     });
   }
 
-  public async refreshUserWorkflowTaskTypeStats(userId: number, type: string, { transaction }: Transactionable = {}) {
+  public async refreshUserWorkflowTaskTypeStats(userId: ID, type: string, { transaction }: Transactionable = {}) {
     const repository = this.db.getRepository('userWorkflowTaskStats');
     const rows = await repository.find({
       filter: {
@@ -743,7 +743,7 @@ export default class PluginWorkflowServer extends Plugin {
   }
 
   public async refreshUserWorkflowTaskWorkflowStats(
-    userId: number,
+    userId: ID,
     workflowKey: string,
     { transaction }: Transactionable = {},
   ) {
@@ -785,7 +785,7 @@ export default class PluginWorkflowServer extends Plugin {
 
   public async updateTaskStatsByWorkflow(
     input: {
-      userId: number;
+      userId: ID;
       workflowKey: string;
       type: string;
       stats: TaskStats;
@@ -991,7 +991,7 @@ export default class PluginWorkflowServer extends Plugin {
    * @deprecated Use updateTaskStatsByWorkflow() when workflowKey is available.
    */
   public async updateTasksStats(
-    userId: number,
+    userId: ID,
     type: string,
     stats: TaskStats = { pending: 0, all: 0 },
     { transaction }: Transactionable,

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/Plugin.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/Plugin.ts
@@ -865,11 +865,7 @@ export default class PluginWorkflowServer extends Plugin {
 
       const typePairs = new Set<string>();
       const workflowPairs = new Set<string>();
-      const getUserIdFromPair = (pair: string): ID => {
-        const userId = pair.slice(0, pair.indexOf('\0'));
-        const numericUserId = Number(userId);
-        return Number.isSafeInteger(numericUserId) ? numericUserId : userId;
-      };
+      const getUserIdFromPair = (pair: string) => pair.slice(0, pair.indexOf('\0'));
       if (options.userIds?.length) {
         for (const userId of options.userIds) {
           for (const [type] of providers) {

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/tasks.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/tasks.test.ts
@@ -298,6 +298,41 @@ describe('workflow > tasks', () => {
       });
     });
 
+    it('preserves user IDs larger than Number.MAX_SAFE_INTEGER when repairing task stats', async () => {
+      const firstUserId = '9007199254740992';
+      const secondUserId = '9007199254740993';
+      plugin.registerTaskStatsProvider('repair-bigint-user-ids', {
+        async collectTaskStats() {
+          return [
+            {
+              userId: firstUserId,
+              workflowKey: 'bigint-workflow',
+              type: 'repair-bigint-user-ids',
+              pending: 1,
+              all: 2,
+            },
+            {
+              userId: secondUserId,
+              workflowKey: 'bigint-workflow',
+              type: 'repair-bigint-user-ids',
+              pending: 3,
+              all: 4,
+            },
+          ];
+        },
+      });
+
+      await plugin.repairTaskStats({ types: ['repair-bigint-user-ids'], silent: true });
+
+      const legacyRows = await TaskRepo.find({
+        filter: {
+          type: 'repair-bigint-user-ids',
+        },
+        sort: 'userId',
+      });
+      expect(legacyRows.map((row) => String(row.get('userId')))).toEqual([firstUserId, secondUserId]);
+    });
+
     it('clears stale legacy stats when the provider finds no business records', async () => {
       plugin.registerTaskStatsProvider('repair-empty', {
         async collectTaskStats() {

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/tasks.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/tasks.test.ts
@@ -301,6 +301,7 @@ describe('workflow > tasks', () => {
     it('preserves user IDs larger than Number.MAX_SAFE_INTEGER when repairing task stats', async () => {
       const firstUserId = '9007199254740992';
       const secondUserId = '9007199254740993';
+      const bulkCreate = vi.spyOn(db.getModel('userWorkflowTasks'), 'bulkCreate');
       plugin.registerTaskStatsProvider('repair-bigint-user-ids', {
         async collectTaskStats() {
           return [
@@ -330,7 +331,9 @@ describe('workflow > tasks', () => {
         },
         sort: 'userId',
       });
-      expect(legacyRows.map((row) => String(row.get('userId')))).toEqual([firstUserId, secondUserId]);
+      expect(legacyRows).toHaveLength(2);
+      const repairedRows = bulkCreate.mock.calls.flatMap(([values]) => values as Array<{ userId: number | string }>);
+      expect(repairedRows.map((row) => row.userId)).toEqual([firstUserId, secondUserId]);
     });
 
     it('clears stale legacy stats when the provider finds no business records', async () => {


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Several workflow and notification paths converted user IDs with `Number()`. IDs larger than `Number.MAX_SAFE_INTEGER` lost precision, which could make distinct users collide when task statistics were repaired or notifications were persisted.

### Description 

- Preserve user IDs as exact decimal strings throughout workflow task-stat repair queries, writes, and notifications.
- Preserve BIGINT IDs in the workflow user selector while retaining number matching for safe integer IDs.
- Allow notification receiver APIs to accept number or string user IDs.
- Preserve resolved receiver IDs when persisting in-app notifications.
- Add regression tests using adjacent BIGINT IDs that previously became the same JavaScript number.

Potential risk: notification receiver types now accept both number and string IDs. Existing safe integer behavior remains compatible. Database BIGINT filters and writes accept exact decimal strings.

Testing suggestions:
- `yarn test packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/tasks.test.ts --run --reporter=verbose`
- `yarn test packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/__tests__/UsersSelect.test.tsx --run --reporter=verbose`
- `yarn test packages/plugins/@nocobase/plugin-notification-in-app-message/src/server/__tests__/server.test.ts --run --reporter=verbose`

### Related issues

N/A

### Showcase

N/A — no visual changes.

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed precision loss for BIGINT user IDs in workflow task statistics and in-app notifications. |
| 🇨🇳 Chinese | 修复工作流任务统计和站内信通知中 BIGINT 用户 ID 精度丢失的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary