### PR TITLE
fix: resolve popup variables in form linkage rules

### DIFF
--- a/packages/core/client-v2/src/flow/models/blocks/form/__tests__/popupLinkage.test.tsx
+++ b/packages/core/client-v2/src/flow/models/blocks/form/__tests__/popupLinkage.test.tsx
@@ -1,0 +1,175 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import React from 'react';
+import { act, render, screen, waitFor, cleanup } from '@testing-library/react';
+import { Form, Input } from 'antd';
+import { afterEach, expect, it, vi } from 'vitest';
+import { FlowEngine, SingleRecordResource } from '@nocobase/flow-engine';
+import { generateFlowModelRdFromToken } from '@nocobase/utils/client';
+import { CreateFormModel, EditFormModel, FormGridModel, FormItemModel, FormComponent } from '../../../..';
+import { fieldLinkageRules, linkageAssignField } from '../../../../actions/linkageRules';
+
+afterEach(cleanup);
+
+it.each([
+  { use: 'CreateFormModel', mode: 'default', expected: 'STAFF-001' },
+  { use: 'EditFormModel', mode: 'default', expected: '' },
+  { use: 'EditFormModel', mode: 'override', expected: 'STAFF-001' },
+])('$use respects $mode linkage after a delayed popup variable response', async ({ use, mode, expected }) => {
+  const uid = `popup-${use}-${mode}`;
+  const engine = new FlowEngine();
+  engine.registerModels({ CreateFormModel, EditFormModel, FormGridModel, FormItemModel });
+  engine.registerActions({ fieldLinkageRules, linkageAssignField });
+  engine.context.dataSourceManager.getDataSource('main').addCollection({
+    name: 't1_user',
+    filterTargetKey: 'id',
+    fields: [
+      { name: 'id', type: 'integer', interface: 'number' },
+      { name: 'staffseq', type: 'string', interface: 'input' },
+      { name: 'staffname', type: 'string', interface: 'input' },
+    ],
+  });
+  const form = engine.createModel<CreateFormModel | EditFormModel>({
+    uid,
+    use,
+    stepParams: { resourceSettings: { init: { dataSourceKey: 'main', collectionName: 't1_user', filterByTk: 1 } } },
+    subModels: {
+      grid: {
+        uid: `${uid}-grid`,
+        use: 'FormGridModel',
+        subModels: {
+          items: [
+            {
+              uid: `${uid}-staffname`,
+              use: 'FormItemModel',
+              props: { name: 'staffname' },
+              stepParams: {
+                fieldSettings: { init: { dataSourceKey: 'main', collectionName: 't1_user', fieldPath: 'staffname' } },
+              },
+            },
+          ],
+        },
+      },
+    },
+  });
+  const configured = '{{ ctx.popup.record.staffseq }}';
+  const rules = {
+    value: [
+      {
+        key: 'rule',
+        title: 'Rule',
+        enable: true,
+        condition: { logic: '$and', items: [] },
+        actions: [
+          {
+            key: 'assign',
+            name: 'linkageAssignField',
+            params: {
+              value: [
+                {
+                  key: 'field',
+                  enable: true,
+                  mode,
+                  condition: { logic: '$and', items: [] },
+                  targetPath: 'staffname',
+                  value: configured,
+                },
+              ],
+            },
+          },
+        ],
+      },
+    ],
+  };
+  form.setStepParams('eventSettings', 'linkageRules', rules);
+  const saved = JSON.parse(JSON.stringify(form.serialize()));
+  expect(saved.subModels.grid.stepParams.eventSettings.linkageRules).toEqual(rules);
+  expect(saved.stepParams.eventSettings?.linkageRules).toBeUndefined();
+
+  const token = `test.${Buffer.from(JSON.stringify({ userId: 2, signInTime: 'member-form' })).toString('base64url')}.sig`;
+  type Item = { id: string; rd: string; template: unknown; contextParams: unknown };
+  let resolveResponse: (() => void) | undefined;
+  const responseReady = new Promise<void>((resolve) => {
+    resolveResponse = resolve;
+  });
+  const request = vi.fn(async ({ data }: { data: { values: { batch: Item[] } } }) => {
+    const batch = data.values.batch;
+    expect(batch[0].rd).toBe(generateFlowModelRdFromToken(form.uid, token));
+    expect(batch[0].contextParams).toEqual({
+      'popup.record': { collection: 't1_user', dataSourceKey: 'main', filterByTk: '1' },
+    });
+    await responseReady;
+    return {
+      data: {
+        data: {
+          results: batch.map((item) => ({
+            id: item.id,
+            data: JSON.parse(JSON.stringify(item.template).replaceAll(configured, 'STAFF-001')),
+          })),
+        },
+      },
+    };
+  });
+  engine.context.defineProperty('api', { value: { auth: { token, role: 'member' }, request } });
+  form.context.defineProperty('popup', {
+    value: { record: { id: 1 } },
+    resolveOnServer: true,
+    meta: {
+      type: 'object',
+      buildVariablesParams: () => ({ record: { collection: 't1_user', dataSourceKey: 'main', filterByTk: '1' } }),
+    },
+  });
+  const resource = form.resource as SingleRecordResource;
+  resource.setData(use === 'EditFormModel' ? { id: 1, staffname: null } : {});
+  function View() {
+    form.useHooksBeforeRender();
+    return (
+      <FormComponent model={form}>
+        <Form.Item name="staffname">
+          <Input aria-label="staffname" />
+        </Form.Item>
+      </FormComponent>
+    );
+  }
+  const dispatchEvent = vi.spyOn(form, 'dispatchEvent');
+  const view = render(<View />);
+  try {
+    form.formValueRuntime?.mount({ sync: true });
+    // Simulate the field mounting, without involving the page layout and field-renderer plugins.
+    engine.emitter.emit('model:mounted', { model: form.subModels.grid.subModels.items[0] });
+    let pending: Promise<unknown> | undefined;
+    await act(async () => {
+      pending = form.applyFlow('eventSettings');
+    });
+    await waitFor(() => expect(request).toHaveBeenCalled());
+    await act(async () => {
+      resolveResponse?.();
+      await pending;
+    });
+    if (mode === 'default') {
+      // Resolving a default value must not overwrite an existing edit record.
+      expect(form.subModels.grid.subModels.items[0].props.initialValue).toBe('STAFF-001');
+    }
+    await waitFor(() => expect((screen.getByLabelText('staffname') as HTMLInputElement).value).toBe(expected));
+    expect(form.form.getFieldValue('staffname')).toBe(expected || null);
+  } finally {
+    resolveResponse?.();
+    await act(async () => {
+      view.unmount();
+      form.formValueRuntime?.dispose();
+      // Drain automatic linkage refreshes before another engine starts its variable batch.
+      await Promise.all(
+        dispatchEvent.mock.results.filter((result) => result.type === 'return').map((result) => result.value),
+      );
+    });
+    dispatchEvent.mockRestore();
+    engine.disposeScheduler();
+  }
+});

--- a/packages/core/flow-engine/src/FlowDefinition.ts
+++ b/packages/core/flow-engine/src/FlowDefinition.ts
@@ -27,6 +27,10 @@ export class FlowDefinition {
     }
   }
 
+  get model() {
+    return this.flowRegistry.model;
+  }
+
   get key() {
     return this.options.key;
   }

--- a/packages/core/flow-engine/src/__tests__/objectVariable.test.ts
+++ b/packages/core/flow-engine/src/__tests__/objectVariable.test.ts
@@ -9,7 +9,8 @@
 
 import { describe, expect, it, vi } from 'vitest';
 import { generateFlowModelRdFromToken } from '@nocobase/utils/client';
-import { FlowContext } from '../flowContext';
+import { FlowContext, FlowRuntimeContext } from '../flowContext';
+import { FlowModel } from '../models';
 import { FlowEngine } from '../flowEngine';
 import {
   createAssociationAwareObjectMetaFactory,
@@ -489,5 +490,40 @@ describe('objectVariable utilities', () => {
     const resolved = await (ctx as any).resolveJsonTemplate(template);
     expect(resolved).toEqual({ x: 'T1' });
     expect((ctx as any).api.request).not.toHaveBeenCalled();
+  });
+
+  it('keeps runtime and configuration descriptors separate for a forwarded instance flow', async () => {
+    const engine = new FlowEngine();
+    const owner = new FlowModel({ uid: 'reference-owner', flowEngine: engine });
+    const target = new FlowModel({ uid: 'reference-target', flowEngine: engine });
+    owner.registerFlow({ key: 'forwarded', steps: {} });
+    const getFlow = vi.spyOn(target, 'getFlow').mockReturnValue(owner.getFlow('forwarded'));
+    const context = new FlowRuntimeContext(target, 'forwarded');
+    getFlow.mockRestore(); // Delayed getVar calls must retain the owner after the event bridge is restored.
+
+    type ResolveItem = { id: string; template: unknown; rd?: string; contractRd?: string };
+    const calls: ResolveItem[] = [];
+    const payload = Buffer.from(JSON.stringify({ userId: 1, signInTime: 'forwarded-flow' })).toString('base64url');
+    const token = `test.${payload}.sig`;
+    engine.context.defineProperty('api', {
+      value: {
+        auth: { token },
+        request: vi.fn(async ({ data }: { data: { values: { batch: ResolveItem[] } } }) => {
+          const batch = data.values.batch;
+          calls.push(...batch);
+          return { data: { data: { results: batch.map((item) => ({ id: item.id, data: 'resolved' })) } } };
+        }),
+      },
+    });
+    target.context.defineProperty('remote', { value: {}, resolveOnServer: true });
+
+    expect(await context.getVar('ctx.remote.name')).toBe('resolved');
+    expect(calls[0].rd).toBe(generateFlowModelRdFromToken(target.uid, token));
+    expect(calls[0].contractRd).toBe(generateFlowModelRdFromToken(owner.uid, token));
+    await context.resolveJsonTemplate('{{ ctx.remote.name }}', { contractModelUid: 'explicit-owner' });
+    expect(calls[1].contractRd).toBe(generateFlowModelRdFromToken('explicit-owner', token));
+    await new FlowRuntimeContext(target, 'local').resolveJsonTemplate('{{ ctx.remote.name }}');
+    expect(calls[2].contractRd).toBeUndefined();
+    expect(owner.getFlow('forwarded')?.serialize()).not.toHaveProperty('model');
   });
 });

--- a/packages/core/flow-engine/src/flow-registry/BaseFlowRegistry.ts
+++ b/packages/core/flow-engine/src/flow-registry/BaseFlowRegistry.ts
@@ -10,10 +10,12 @@
 import { FlowDefinitionOptions } from '../types';
 import { FlowDefinition } from '../FlowDefinition';
 import { observable } from '@formily/reactive';
+import type { FlowModel } from '../models';
 
 type FlowKey = string;
 
 export interface IFlowRepository {
+  readonly model?: FlowModel;
   addFlows(flowDefs: Record<string, Omit<FlowDefinitionOptions, 'key'>>): void;
   addFlow(flowKey: string, flowOptions: Omit<FlowDefinitionOptions, 'key'>): FlowDefinition | void;
   removeFlow(flowKey: string): void;

--- a/packages/core/flow-engine/src/flow-registry/InstanceFlowRegistry.ts
+++ b/packages/core/flow-engine/src/flow-registry/InstanceFlowRegistry.ts
@@ -15,7 +15,7 @@ type FlowKey = string;
 
 export class InstanceFlowRegistry extends BaseFlowRegistry {
   static readonly _type = 'instance' as const;
-  constructor(protected model: FlowModel) {
+  constructor(public readonly model: FlowModel) {
     super();
   }
 

--- a/packages/core/flow-engine/src/flowContext.ts
+++ b/packages/core/flow-engine/src/flowContext.ts
@@ -3051,6 +3051,7 @@ class BaseFlowEngineContext extends FlowContext {
    */
   declare renderJson: (template: JSONValue) => Promise<any>;
   declare resolveJsonTemplate: (template: JSONValue, options?: ResolveJsonTemplateOptions) => Promise<any>;
+  declare variableContractModelUid?: string;
   declare getVar: (path: string) => Promise<any>;
   declare request: (options: RequestOptions) => Promise<any>;
   declare runjs: (code: string, variables?: Record<string, any>, options?: JSRunnerOptions) => Promise<any>;
@@ -3408,7 +3409,7 @@ export class FlowEngineContext extends BaseFlowEngineContext {
           try {
             const contractRd = buildFlowModelResolveDescriptor(
               this as FlowRuntimeContext<FlowModel>,
-              options?.contractModelUid,
+              options?.contractModelUid ?? this.variableContractModelUid,
             );
             serverResolved = await enqueueVariablesResolve(this as FlowRuntimeContext<FlowModel>, {
               ...(contractRd ? { contractRd } : {}),
@@ -3943,6 +3944,11 @@ export class FlowRuntimeContext<
   ) {
     super();
     this.addDelegate(this.model.context);
+    const owner = model.getFlow?.(flowKey)?.model;
+    if (owner && owner.uid !== model.uid) {
+      // A forwarded instance flow keeps its configuration owner, without changing the runtime model.
+      this.defineProperty('variableContractModelUid', { value: owner.uid });
+    }
     this.defineMethod('getStepParams', (stepKey: string) => {
       return model.getStepParams(flowKey, stepKey) || {};
     });

--- a/packages/plugins/@nocobase/plugin-flow-engine/src/server/__tests__/variables.allow-list.test.ts
+++ b/packages/plugins/@nocobase/plugin-flow-engine/src/server/__tests__/variables.allow-list.test.ts
@@ -1580,4 +1580,137 @@ describe('variables:resolve allow-list authorization', () => {
     expect(result.analysis.supported).toBe(false);
     expect(result.policy.allowAll).toBe(false);
   });
+
+  it('collects only linkage variables from the referenced form and grid', async () => {
+    const session = createTokenSession();
+    const configured = '{{ ctx.popup.record.name }}';
+    const unrelated = '{{ ctx.popup.record.secret }}';
+    const host = { ...createFlowModel('linkage-host', {}), options: { use: 'EditFormModel' } };
+    const target = {
+      ...createFlowModel('linkage-target', unrelated),
+      options: {
+        use: 'EditFormModel',
+        props: { unrelated },
+      },
+    };
+    const reference = {
+      ...createFlowModel('linkage-reference', {}),
+      parentId: host.uid,
+      subKey: 'grid',
+      options: {
+        use: 'ReferenceFormGridModel',
+        stepParams: {
+          referenceSettings: {
+            useTemplate: {
+              templateUid: 'linkage-template',
+              targetUid: target.uid,
+              targetPath: 'subModels.grid',
+            },
+          },
+        },
+      },
+    };
+    const grid = {
+      ...createFlowModel('linkage-target-grid', {}),
+      parentId: target.uid,
+      subKey: 'grid',
+      options: {
+        use: 'FormGridModel',
+        stepParams: {
+          eventSettings: {
+            linkageRules: {
+              value: [
+                {
+                  actions: [
+                    {
+                      name: 'linkageAssignField',
+                      params: {
+                        value: [
+                          {
+                            value: { code: "return await ctx.getVar('ctx.popup.record.name');", version: 'v2' },
+                          },
+                        ],
+                      },
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+        },
+      },
+    };
+    const ctx = createFakeCtx({
+      token: session.token,
+      models: Object.fromEntries([host, reference, target, grid].map((node) => [node.uid, node])),
+    });
+    expect((await authorizeVariablesResolve(ctx, { rd: session.rd(host.uid), template: configured })).allowed).toBe(
+      true,
+    );
+    expect((await authorizeVariablesResolve(ctx, { rd: session.rd(host.uid), template: unrelated })).allowed).toBe(
+      false,
+    );
+  });
+
+  it.each(['direct', 'chain', 'missing', 'cycle', 'unrelated'])(
+    'validates the persisted reference event contract: %s',
+    async (scenario) => {
+      const session = createTokenSession();
+      const template = '{{ ctx.popup.record.name }}';
+      const target = createFlowModel('event-target', {});
+      const reference = {
+        ...createFlowModel('event-reference', {}),
+        options: {
+          use: 'ReferenceBlockModel',
+          stepParams: {
+            referenceSettings: {
+              target: {
+                targetUid:
+                  scenario === 'direct' || scenario === 'unrelated'
+                    ? target.uid
+                    : scenario === 'missing'
+                      ? 'missing'
+                      : 'event-reference-2',
+              },
+            },
+            instanceEvent: { configure: { value: template } },
+          },
+        },
+      };
+      const secondReference = {
+        ...createFlowModel('event-reference-2', {}),
+        options: {
+          use: 'ReferenceBlockModel',
+          stepParams: {
+            referenceSettings: {
+              target: { targetUid: scenario === 'cycle' ? reference.uid : target.uid },
+            },
+          },
+        },
+      };
+      const other = createFlowModel('unrelated-target', {});
+      const ctx = createFakeCtx({
+        token: session.token,
+        models: Object.fromEntries([target, reference, secondReference, other].map((node) => [node.uid, node])),
+      });
+      const result = await authorizeVariablesResolve(ctx, {
+        rd: session.rd(scenario === 'unrelated' ? other.uid : target.uid),
+        contractRd: session.rd(reference.uid),
+        template,
+      });
+      expect(result.allowed).toBe(scenario === 'direct' || scenario === 'chain');
+      if (result.allowed) {
+        expect(result.flowModelUid).toBe(target.uid);
+        expect(
+          (
+            await authorizeVariablesResolve(ctx, {
+              rd: session.rd(target.uid),
+              contractRd: session.rd(reference.uid),
+              template: '{{ ctx.popup.record.secret }}',
+            })
+          ).allowed,
+        ).toBe(false);
+      }
+    },
+  );
 });

--- a/packages/plugins/@nocobase/plugin-flow-engine/src/server/__tests__/variables.allow-list.test.ts
+++ b/packages/plugins/@nocobase/plugin-flow-engine/src/server/__tests__/variables.allow-list.test.ts
@@ -1587,6 +1587,7 @@ describe('variables:resolve allow-list authorization', () => {
     `return ctx.resolveJsonTemplate('{{ ctx.popup.record.name }}', {});`,
     `const template = { value: '{{ ctx.popup.record.name }}' }; return ctx.resolveJsonTemplate(template);`,
     `const template = ['{{ ctx.popup.record.name }}']; return ctx.resolveJsonTemplate(template);`,
+    `const template = { name: '{{ ctx.popup.record.name }}' }; return ctx.resolveJsonTemplate(template.name);`,
     `return ctx.resolveJsonTemplate('{{ ctx.popup.record.name }}');`.padEnd(70 * 1024),
   ])('authorizes explicit V2 filter default templates for ordinary users: case %#', async (code) => {
     const session = createTokenSession();
@@ -1745,6 +1746,46 @@ describe('variables:resolve allow-list authorization', () => {
     const ctx = createFakeCtx({ token: session.token, models: { [target.uid]: target, [reference.uid]: reference } });
     for (const [path, allowed] of [
       ['target', true],
+      ['instance', true],
+      ['secret', false],
+    ] as const) {
+      const result = await authorizeVariablesResolve(ctx, {
+        rd: session.rd(target.uid),
+        contractRd: session.rd(reference.uid),
+        template: `{{ ctx.popup.record.${path} }}`,
+      });
+      expect(result.allowed).toBe(allowed);
+      expect(result.flowModelUid).toBe(target.uid);
+    }
+  });
+
+  it.each(['count', 'length'] as const)('isolates reference and target AST %s budgets', async (limit) => {
+    const session = createTokenSession();
+    const target = createJsBlockModel('budget-target', "return ctx.getVar('ctx.popup.record.name');");
+    const code = "return ctx.getVar('ctx.popup.record.instance');";
+    const reference = {
+      ...createFlowModel('budget-reference', {}),
+      options: {
+        use: 'ReferenceBlockModel',
+        stepParams: { referenceSettings: { target: { targetUid: target.uid } } },
+        flowRegistry: {
+          custom: {
+            steps: Object.fromEntries(
+              Array.from({ length: limit === 'count' ? 100 : 4 }, (_, index) => [
+                `step${index}`,
+                {
+                  use: 'runjs',
+                  defaultParams: { code: limit === 'length' ? code.padEnd(64 * 1024) : code, version: 'v2' },
+                },
+              ]),
+            ),
+          },
+        },
+      },
+    };
+    const ctx = createFakeCtx({ token: session.token, models: { [target.uid]: target, [reference.uid]: reference } });
+    for (const [path, allowed] of [
+      ['name', true],
       ['instance', true],
       ['secret', false],
     ] as const) {

--- a/packages/plugins/@nocobase/plugin-flow-engine/src/server/__tests__/variables.allow-list.test.ts
+++ b/packages/plugins/@nocobase/plugin-flow-engine/src/server/__tests__/variables.allow-list.test.ts
@@ -1585,7 +1585,10 @@ describe('variables:resolve allow-list authorization', () => {
     `return ctx.resolveJsonTemplate('{{ ctx.popup.record.name }}');`,
     `const template = '{{ ctx.popup.record.name }}'; return ctx.resolveJsonTemplate(template);`,
     `return ctx.resolveJsonTemplate('{{ ctx.popup.record.name }}', {});`,
-  ])('authorizes explicit V2 filter default templates for ordinary users: %s', async (code) => {
+    `const template = { value: '{{ ctx.popup.record.name }}' }; return ctx.resolveJsonTemplate(template);`,
+    `const template = ['{{ ctx.popup.record.name }}']; return ctx.resolveJsonTemplate(template);`,
+    `return ctx.resolveJsonTemplate('{{ ctx.popup.record.name }}');`.padEnd(70 * 1024),
+  ])('authorizes explicit V2 filter default templates for ordinary users: case %#', async (code) => {
     const session = createTokenSession();
     const form = {
       ...createFlowModel('filter-default', {}),
@@ -1723,6 +1726,36 @@ describe('variables:resolve allow-list authorization', () => {
     expect((await authorizeVariablesResolve(ctx, { rd: session.rd(host.uid), template: unrelated })).allowed).toBe(
       false,
     );
+  });
+
+  it('preserves both reference owners when their combined source exceeds the node budget', async () => {
+    const session = createTokenSession();
+    const target = createFlowModel('large-target', {
+      value: '{{ ctx.popup.record.target }}',
+      padding: Array(6000).fill(0),
+    });
+    const reference = {
+      ...createFlowModel('large-reference', {}),
+      options: {
+        use: 'ReferenceBlockModel',
+        stepParams: { referenceSettings: { target: { targetUid: target.uid } } },
+        props: { value: '{{ ctx.popup.record.instance }}', padding: Array(6000).fill(0) },
+      },
+    };
+    const ctx = createFakeCtx({ token: session.token, models: { [target.uid]: target, [reference.uid]: reference } });
+    for (const [path, allowed] of [
+      ['target', true],
+      ['instance', true],
+      ['secret', false],
+    ] as const) {
+      const result = await authorizeVariablesResolve(ctx, {
+        rd: session.rd(target.uid),
+        contractRd: session.rd(reference.uid),
+        template: `{{ ctx.popup.record.${path} }}`,
+      });
+      expect(result.allowed).toBe(allowed);
+      expect(result.flowModelUid).toBe(target.uid);
+    }
   });
 
   it.each(['direct', 'chain', 'missing', 'cycle', 'unrelated'])(

--- a/packages/plugins/@nocobase/plugin-flow-engine/src/server/__tests__/variables.allow-list.test.ts
+++ b/packages/plugins/@nocobase/plugin-flow-engine/src/server/__tests__/variables.allow-list.test.ts
@@ -26,6 +26,7 @@ type FakeCtxOptions = {
   allowConfigure?: boolean;
   currentRole?: string;
   fieldKinds?: Record<string, 'association' | 'field'>;
+  findModelById?: (uid: string, options?: { includeAsyncNode?: boolean }) => Promise<unknown>;
   findModelNodeSnapshotByParentId?: (parentUid: string, options?: { subKey?: string }) => Promise<unknown>;
   findModelNodeSnapshotById?: (uid: string) => Promise<unknown>;
   findRoles?: () => Promise<unknown[]>;
@@ -82,6 +83,7 @@ function createFakeCtx(options: FakeCtxOptions = {}) {
         if (name === 'flowModels') {
           return {
             repository: {
+              findModelById: options.findModelById,
               findModelNodeSnapshotByParentId:
                 options.findModelNodeSnapshotByParentId ||
                 (async (parentUid: string, query?: { subKey?: string }) => {
@@ -1613,6 +1615,67 @@ describe('variables:resolve allow-list authorization', () => {
       });
       expect(result.allowed).toBe(allowed);
     }
+  });
+
+  it.each([0, 1, 8])('loads each form tree once per request for %i repeated linkage references', async (count) => {
+    const session = createTokenSession();
+    const models: Record<string, unknown> = {};
+    const trees: Record<string, unknown> = {};
+    const formUids = ['cached-linkage-form', 'another-linkage-form'];
+    for (const uid of formUids) {
+      const fullForm = createEditFormModel(uid, '{{ ctx.popup.record.id }}', []);
+      const { subModels, ...options } = fullForm.options;
+      // Repository snapshots omit subModels, so resolving formValues must load the persisted tree.
+      models[uid] = { ...fullForm, options };
+      trees[uid] = fullForm.options;
+      models[`${uid}-grid`] = {
+        ...createFlowModel(`${uid}-grid`, {}),
+        parentId: uid,
+        subKey: 'grid',
+        options: {
+          use: 'FormGridModel',
+          stepParams: {
+            eventSettings: {
+              linkageRules: {
+                value: Array.from({ length: count }, () => ({
+                  condition: {
+                    logic: '$and',
+                    items: [{ left: '{{ ctx.formValues.status }}', operator: '$eq', right: 'active' }],
+                  },
+                })),
+              },
+            },
+          },
+        },
+      };
+    }
+    const findModelById = vi.fn(async (uid: string) => trees[uid]);
+    const expectedLoads = count ? 1 : 0;
+    // A fresh context must reload the same UIDs; different UIDs must not share a cached tree.
+    for (let request = 0; request < 2; request++) {
+      const ctx = createFakeCtx({ token: session.token, models, findModelById, fieldKinds: { status: 'field' } });
+      const resolveOccurrence = vi.fn(() => ({ status: 'abstain' as const }));
+      getRecordSlotResolverRegistry(ctx.app).register({
+        owner: 'test',
+        id: 'observe-linkage-occurrences',
+        match: (path) => path.varName === 'formValues',
+        resolve: resolveOccurrence,
+      });
+      for (const uid of formUids) {
+        const result = await authorizeVariablesResolve(ctx, {
+          rd: session.rd(uid),
+          template: '{{ ctx.popup.record.id }}',
+        });
+        expect(result.allowed).toBe(true);
+        expect(findModelById.mock.calls.filter(([loadedUid]) => loadedUid === uid)).toHaveLength(
+          (request + 1) * expectedLoads,
+        );
+        if (count) expect(findModelById).toHaveBeenCalledWith(uid, { includeAsyncNode: true });
+      }
+      // Tree caching must preserve per-expression resolver calls, including duplicate field references.
+      expect(resolveOccurrence).toHaveBeenCalledTimes(count * formUids.length);
+    }
+    expect(findModelById).toHaveBeenCalledTimes(2 * formUids.length * expectedLoads);
   });
 
   it.each(['string', 'nodes'])(

--- a/packages/plugins/@nocobase/plugin-flow-engine/src/server/__tests__/variables.allow-list.test.ts
+++ b/packages/plugins/@nocobase/plugin-flow-engine/src/server/__tests__/variables.allow-list.test.ts
@@ -1581,6 +1581,79 @@ describe('variables:resolve allow-list authorization', () => {
     expect(result.policy.allowAll).toBe(false);
   });
 
+  it.each([
+    `return ctx.resolveJsonTemplate('{{ ctx.popup.record.name }}');`,
+    `const template = '{{ ctx.popup.record.name }}'; return ctx.resolveJsonTemplate(template);`,
+    `return ctx.resolveJsonTemplate('{{ ctx.popup.record.name }}', {});`,
+  ])('authorizes explicit V2 filter default templates for ordinary users: %s', async (code) => {
+    const session = createTokenSession();
+    const form = {
+      ...createFlowModel('filter-default', {}),
+      options: {
+        use: 'FilterFormBlockModel',
+        stepParams: {
+          formFilterBlockModelSettings: {
+            defaultValues: { value: [{ value: { code, version: 'v2' } }] },
+          },
+        },
+      },
+    };
+    const ctx = createFakeCtx({ token: session.token, models: { [form.uid]: form } });
+    for (const [path, allowed] of [
+      ['name', true],
+      ['secret', false],
+    ] as const) {
+      const result = await authorizeVariablesResolve(ctx, {
+        rd: session.rd(form.uid),
+        template: `{{ ctx.popup.record.${path} }}`,
+      });
+      expect(result.allowed).toBe(allowed);
+    }
+  });
+
+  it.each(['string', 'nodes'])(
+    'preserves host dependencies when supplemental linkage exceeds %s limits',
+    async (limit) => {
+      const session = createTokenSession();
+      const form = createEditFormModel('oversized-linkage-host', '{{ ctx.popup.record.id }}', []);
+      const grid = {
+        ...createFlowModel('oversized-linkage-grid', {}),
+        parentId: form.uid,
+        subKey: 'grid',
+        options: {
+          use: 'FormGridModel',
+          stepParams: {
+            eventSettings: {
+              linkageRules: {
+                value: [
+                  '{{ ctx.popup.record.secret }}',
+                  limit === 'string'
+                    ? 'x'.repeat(MAX_FLOW_MODEL_VARIABLE_STRING_LENGTH + 1)
+                    : Array.from({ length: MAX_FLOW_MODEL_VARIABLE_SOURCE_NODES }, () => 0),
+                ],
+              },
+            },
+          },
+        },
+      };
+      const ctx = createFakeCtx({
+        token: session.token,
+        models: { [form.uid]: form, [grid.uid]: grid },
+      });
+      for (const [path, allowed] of [
+        ['id', true],
+        ['secret', false],
+        ['unconfigured', false],
+      ] as const) {
+        const result = await authorizeVariablesResolve(ctx, {
+          rd: session.rd(form.uid),
+          template: `{{ ctx.popup.record.${path} }}`,
+        });
+        expect(result.allowed).toBe(allowed);
+      }
+    },
+  );
+
   it('collects only linkage variables from the referenced form and grid', async () => {
     const session = createTokenSession();
     const configured = '{{ ctx.popup.record.name }}';

--- a/packages/plugins/@nocobase/plugin-flow-engine/src/server/__tests__/variables.resolve.external-data-source.test.ts
+++ b/packages/plugins/@nocobase/plugin-flow-engine/src/server/__tests__/variables.resolve.external-data-source.test.ts
@@ -336,7 +336,12 @@ describe('variables:resolve external data source records', () => {
         logger: { child: () => ({ debug: vi.fn(), warn: vi.fn() }) },
       },
       db: {
-        getCollection: () => ({ repository: { findModelNodeSnapshotById: async () => flowModel } }),
+        getCollection: () => ({
+          repository: {
+            findModelNodeSnapshotById: async () => flowModel,
+            findModelNodeSnapshotByParentId: async () => null,
+          },
+        }),
         getRepository: () => ({ find: async () => [] }),
       },
       get: (name: string) => (name.toLowerCase() === 'authorization' ? `Bearer ${token}` : undefined),

--- a/packages/plugins/@nocobase/plugin-flow-engine/src/server/__tests__/variables.resolve.form-linkage.test.ts
+++ b/packages/plugins/@nocobase/plugin-flow-engine/src/server/__tests__/variables.resolve.form-linkage.test.ts
@@ -1,0 +1,133 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import type { ResourcerContext } from '@nocobase/resourcer';
+import type { MockServer } from '@nocobase/test';
+import { generateFlowModelRd } from '@nocobase/utils';
+import type FlowModelRepository from '../repository';
+import { createFlowEngineMockServer, resetVariablesRegistryForTest } from './test-utils';
+
+function linkageRules(value: string) {
+  return {
+    value: [
+      {
+        key: 'popup-linkage',
+        title: 'Popup linkage',
+        enable: true,
+        condition: { logic: '$and', items: [] },
+        actions: [
+          {
+            key: 'assign-field',
+            name: 'linkageAssignField',
+            params: {
+              value: [
+                {
+                  key: 'staff-default',
+                  enable: true,
+                  mode: 'default',
+                  condition: { logic: '$and', items: [] },
+                  targetPath: 'staffname',
+                  value,
+                },
+              ],
+            },
+          },
+        ],
+      },
+    ],
+  };
+}
+
+describe('variables:resolve form grid linkage rules', () => {
+  let app: MockServer;
+  let filterByTk: number;
+  const formUid = 'popup-edit-form';
+  const configured = '{{ ctx.popup.record.staffseq }}';
+  const unconfigured = '{{ ctx.popup.record.staffname }}';
+
+  beforeAll(async () => {
+    resetVariablesRegistryForTest();
+    app = await createFlowEngineMockServer({
+      plugins: [
+        'error-handler',
+        'auth',
+        'users',
+        'acl',
+        'data-source-manager',
+        'data-source-main',
+        'field-sort',
+        'flow-engine',
+      ],
+    });
+    app.db.collection({
+      name: 'popup_staff',
+      fields: [
+        { name: 'staffseq', type: 'string' },
+        { name: 'staffname', type: 'string' },
+      ],
+    });
+    await app.db.sync();
+    const record = await app.db.getRepository('popup_staff').create({
+      values: { staffseq: 'STAFF-001', staffname: 'Example' },
+    });
+    filterByTk = record.get('id');
+    const repository = app.db.getCollection('flowModels').repository as FlowModelRepository;
+    await repository.insertModel({
+      uid: formUid,
+      use: 'EditFormModel',
+      subModels: {
+        grid: {
+          uid: `${formUid}-grid`,
+          use: 'FormGridModel',
+          stepParams: { eventSettings: { linkageRules: linkageRules(configured) } },
+        },
+      },
+    });
+  });
+
+  afterAll(async () => {
+    await app?.destroy();
+  });
+
+  it('resolves configured popup fields for member without allowing unconfigured fields', async () => {
+    const signInTime = 'form-linkage-test';
+    const payload = Buffer.from(JSON.stringify({ userId: 1, signInTime })).toString('base64url');
+    const token = `test.${payload}.sig`;
+    const rd = generateFlowModelRd(formUid, `1:${signInTime}`);
+    const values = {
+      batch: [configured, unconfigured].map((value, id) => ({
+        id,
+        rd,
+        template: linkageRules(value),
+        contextParams: { 'popup.record': { collection: 'popup_staff', dataSourceKey: 'main', filterByTk } },
+      })),
+    };
+    const action = app.resourceManager.getAction('variables', 'resolve').clone();
+    action.mergeParams({ values });
+    const ctx = {
+      app,
+      db: app.db,
+      action,
+      auth: { user: { id: 1 }, role: 'member' },
+      state: { currentRole: 'member', currentRoles: ['member'] },
+      get: (name: string) => (name.toLowerCase() === 'authorization' ? `Bearer ${token}` : ''),
+      getCurrentLocale: () => 'en-US',
+      request: { method: 'POST', path: '/api/variables:resolve', query: {}, body: values },
+    } as unknown as ResourcerContext;
+
+    await action.execute(ctx, async () => {});
+
+    expect(ctx.body).toEqual({
+      results: [
+        { id: 0, data: linkageRules('STAFF-001') },
+        { id: 1, data: linkageRules(unconfigured) },
+      ],
+    });
+  });
+});

--- a/packages/plugins/@nocobase/plugin-flow-engine/src/server/__tests__/variables.resolve.form-linkage.test.ts
+++ b/packages/plugins/@nocobase/plugin-flow-engine/src/server/__tests__/variables.resolve.form-linkage.test.ts
@@ -89,45 +89,76 @@ describe('variables:resolve form grid linkage rules', () => {
         },
       },
     });
+    for (const legacy of [false, true]) {
+      const hostUid = legacy ? 'legacy-reference-form' : 'reference-form';
+      const targetUid = `${hostUid}-template`;
+      const rules = { eventSettings: { linkageRules: linkageRules(configured) } };
+      await repository.insertModel({
+        uid: targetUid,
+        use: 'EditFormModel',
+        stepParams: legacy ? rules : {},
+        subModels: {
+          grid: { uid: `${targetUid}-grid`, use: 'FormGridModel', stepParams: legacy ? {} : rules },
+        },
+      });
+      await repository.insertModel({
+        uid: hostUid,
+        use: 'EditFormModel',
+        subModels: {
+          grid: {
+            uid: `${hostUid}-grid`,
+            use: 'ReferenceFormGridModel',
+            stepParams: {
+              referenceSettings: {
+                useTemplate: { templateUid: `${hostUid}-template-id`, targetUid, targetPath: 'subModels.grid' },
+              },
+            },
+          },
+        },
+      });
+    }
   });
 
   afterAll(async () => {
     await app?.destroy();
   });
 
-  it('resolves configured popup fields for member without allowing unconfigured fields', async () => {
-    const signInTime = 'form-linkage-test';
-    const payload = Buffer.from(JSON.stringify({ userId: 1, signInTime })).toString('base64url');
-    const token = `test.${payload}.sig`;
-    const rd = generateFlowModelRd(formUid, `1:${signInTime}`);
-    const values = {
-      batch: [configured, unconfigured].map((value, id) => ({
-        id,
-        rd,
-        template: linkageRules(value),
-        contextParams: { 'popup.record': { collection: 'popup_staff', dataSourceKey: 'main', filterByTk } },
-      })),
-    };
-    const action = app.resourceManager.getAction('variables', 'resolve').clone();
-    action.mergeParams({ values });
-    const ctx = {
-      app,
-      db: app.db,
-      action,
-      auth: { user: { id: 1 }, role: 'member' },
-      state: { currentRole: 'member', currentRoles: ['member'] },
-      get: (name: string) => (name.toLowerCase() === 'authorization' ? `Bearer ${token}` : ''),
-      getCurrentLocale: () => 'en-US',
-      request: { method: 'POST', path: '/api/variables:resolve', query: {}, body: values },
-    } as unknown as ResourcerContext;
+  it.each([formUid, 'reference-form', 'legacy-reference-form'])(
+    'resolves configured popup fields for member from %s without allowing unconfigured fields',
+    async (modelUid) => {
+      const signInTime = 'form-linkage-test';
+      const payload = Buffer.from(JSON.stringify({ userId: 1, signInTime })).toString('base64url');
+      const token = `test.${payload}.sig`;
+      const rd = generateFlowModelRd(modelUid, `1:${signInTime}`);
+      const values = {
+        batch: [configured, unconfigured].map((value, id) => ({
+          id,
+          rd,
+          template: linkageRules(value),
+          contextParams: { 'popup.record': { collection: 'popup_staff', dataSourceKey: 'main', filterByTk } },
+        })),
+      };
+      const action = app.resourceManager.getAction('variables', 'resolve').clone();
+      action.mergeParams({ values });
+      const ctx = {
+        app,
+        db: app.db,
+        action,
+        auth: { user: { id: 1 }, role: 'member' },
+        state: { currentRole: 'member', currentRoles: ['member'] },
+        get: (name: string) => (name.toLowerCase() === 'authorization' ? `Bearer ${token}` : ''),
+        getCurrentLocale: () => 'en-US',
+        request: { method: 'POST', path: '/api/variables:resolve', query: {}, body: values },
+      } as unknown as ResourcerContext;
 
-    await action.execute(ctx, async () => {});
+      await action.execute(ctx, async () => {});
 
-    expect(ctx.body).toEqual({
-      results: [
-        { id: 0, data: linkageRules('STAFF-001') },
-        { id: 1, data: linkageRules(unconfigured) },
-      ],
-    });
-  });
+      expect(ctx.body).toEqual({
+        results: [
+          { id: 0, data: linkageRules('STAFF-001') },
+          { id: 1, data: linkageRules(unconfigured) },
+        ],
+      });
+    },
+  );
 });

--- a/packages/plugins/@nocobase/plugin-flow-engine/src/server/__tests__/variables.resolve.form-linkage.test.ts
+++ b/packages/plugins/@nocobase/plugin-flow-engine/src/server/__tests__/variables.resolve.form-linkage.test.ts
@@ -9,6 +9,7 @@
 
 import type { MockServer } from '@nocobase/test';
 import { generateFlowModelRdFromToken } from '@nocobase/utils';
+import { vi } from 'vitest';
 import {
   MAX_RUNJS_SOURCES_PER_REQUEST,
   MAX_RUNJS_SOURCE_LENGTH,
@@ -200,6 +201,69 @@ describe('variables:resolve form grid linkage rules', () => {
       });
     },
   );
+
+  it.each([0, 1, 8])('queries the form tree at most once for %i repeated linkage conditions', async (count) => {
+    const modelUid = `linkage-query-count-${count}`;
+    const repository = app.db.getCollection('flowModels').repository as FlowModelRepository;
+    const conditions = Array.from({ length: count }, () => ({
+      left: '{{ ctx.formValues.staffname }}',
+      operator: '$eq',
+      right: 'Example',
+    }));
+    await repository.insertModel({
+      uid: modelUid,
+      use: 'EditFormModel',
+      stepParams: { resourceSettings: { init: { collectionName: 'popup_staff', dataSourceKey: 'main' } } },
+      subModels: {
+        grid: {
+          uid: `${modelUid}-grid`,
+          use: 'FormGridModel',
+          stepParams: {
+            eventSettings: {
+              linkageRules: {
+                value: linkageRules(configured).value.map((rule) => ({
+                  ...rule,
+                  condition: { logic: '$and', items: conditions },
+                })),
+              },
+            },
+          },
+          subModels: {
+            items: [
+              {
+                uid: `${modelUid}-field`,
+                use: 'FormItemModel',
+                async: true,
+                stepParams: { fieldSettings: { init: { fieldPath: 'staffname' } } },
+              },
+            ],
+          },
+        },
+      },
+    });
+    const findNodes = vi.spyOn(repository, 'findNodesById');
+    try {
+      const response = await app
+        .agent()
+        .post('/api/variables:resolve')
+        .auth(memberToken, { type: 'bearer' })
+        .set('X-Authenticator', 'basic')
+        .set('X-Role', 'member')
+        .send({
+          values: {
+            rd: generateFlowModelRdFromToken(modelUid, memberToken),
+            template: configured,
+            contextParams: { 'popup.record': { collection: 'popup_staff', filterByTk } },
+          },
+        });
+      expect(response.status).toBe(200);
+      expect(response.body.data).toBe('STAFF-001');
+      expect(findNodes.mock.calls.filter(([uid]) => uid === modelUid)).toHaveLength(count ? 1 : 0);
+      if (count) expect(findNodes).toHaveBeenCalledWith(modelUid, { includeAsyncNode: true });
+    } finally {
+      findNodes.mockRestore();
+    }
+  });
 
   it.each(['option', 'events'])('resolves member variables in a saved 70 KiB chart %s script', async (source) => {
     const modelUid = 'large-chart-' + source;

--- a/packages/plugins/@nocobase/plugin-flow-engine/src/server/__tests__/variables.resolve.form-linkage.test.ts
+++ b/packages/plugins/@nocobase/plugin-flow-engine/src/server/__tests__/variables.resolve.form-linkage.test.ts
@@ -10,6 +10,8 @@
 import type { MockServer } from '@nocobase/test';
 import { generateFlowModelRdFromToken } from '@nocobase/utils';
 import { vi } from 'vitest';
+import { JSRunner } from '../../../../../../core/flow-engine/src/JSRunner';
+import { prepareRunJsCode } from '../../../../../../core/flow-engine/src/utils/runjsTemplateCompat';
 import {
   MAX_RUNJS_SOURCES_PER_REQUEST,
   MAX_RUNJS_SOURCE_LENGTH,
@@ -264,6 +266,43 @@ describe('variables:resolve form grid linkage rules', () => {
       findNodes.mockRestore();
     }
   });
+
+  it.each(['v1', undefined])(
+    'runs saved %s new.target scripts with member HTTP variable resolution',
+    async (version) => {
+      const modelUid = `legacy-new-target-${version || 'default'}`;
+      const code = `return new.target || '${configured}'; // ${unconfigured}`;
+      const saved = await app
+        .agent()
+        .post('/api/flowModels:save')
+        .auth(rootToken, { type: 'bearer' })
+        .set('X-Authenticator', 'basic')
+        .set('X-Role', 'root')
+        .send({ uid: modelUid, use: 'JSBlockModel', stepParams: { jsSettings: { runJs: { code, version } } } });
+      expect(saved.status).toBe(200);
+      const resolveJsonTemplate = async (template: string) => {
+        const response = await app
+          .agent()
+          .post('/api/variables:resolve')
+          .auth(memberToken, { type: 'bearer' })
+          .set('X-Authenticator', 'basic')
+          .set('X-Role', 'member')
+          .send({
+            values: {
+              rd: generateFlowModelRdFromToken(modelUid, memberToken),
+              template,
+              contextParams: { 'popup.record': { collection: 'popup_staff', filterByTk } },
+            },
+          });
+        expect(response.status).toBe(200);
+        return response.body.data;
+      };
+      const runner = new JSRunner({ globals: { ctx: { resolveJsonTemplate } } });
+      const prepared = await prepareRunJsCode(code, { preprocessTemplates: true });
+      expect(await runner.run(prepared)).toEqual({ success: true, value: 'STAFF-001' });
+      expect(await resolveJsonTemplate(unconfigured)).toBe(unconfigured);
+    },
+  );
 
   it.each([
     ['block', "if (true) /[/*]/.test('/');\n"],

--- a/packages/plugins/@nocobase/plugin-flow-engine/src/server/__tests__/variables.resolve.form-linkage.test.ts
+++ b/packages/plugins/@nocobase/plugin-flow-engine/src/server/__tests__/variables.resolve.form-linkage.test.ts
@@ -7,9 +7,8 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import type { ResourcerContext } from '@nocobase/resourcer';
 import type { MockServer } from '@nocobase/test';
-import { generateFlowModelRd } from '@nocobase/utils';
+import { generateFlowModelRdFromToken } from '@nocobase/utils';
 import type FlowModelRepository from '../repository';
 import { createFlowEngineMockServer, resetVariablesRegistryForTest } from './test-utils';
 
@@ -47,6 +46,8 @@ function linkageRules(value: string) {
 describe('variables:resolve form grid linkage rules', () => {
   let app: MockServer;
   let filterByTk: number;
+  let memberToken: string;
+  let rootToken: string;
   const formUid = 'popup-edit-form';
   const configured = '{{ ctx.popup.record.staffseq }}';
   const unconfigured = '{{ ctx.popup.record.staffname }}';
@@ -54,6 +55,8 @@ describe('variables:resolve form grid linkage rules', () => {
   beforeAll(async () => {
     resetVariablesRegistryForTest();
     app = await createFlowEngineMockServer({
+      acl: true,
+      resourcer: { prefix: '/api' },
       plugins: [
         'error-handler',
         'auth',
@@ -65,6 +68,17 @@ describe('variables:resolve form grid linkage rules', () => {
         'flow-engine',
       ],
     });
+    const root = await app.db.getRepository('users').findOne({ filter: { 'roles.name': 'root' } });
+    const member = await app.db
+      .getRepository('users')
+      .create({ values: { nickname: 'linkage-member', roles: ['member'] } });
+    rootToken = await app.authManager.jwt.sign({ userId: root.id, roleName: 'root', signInTime: 'linkage-root' });
+    memberToken = await app.authManager.jwt.sign({
+      userId: member.id,
+      roleName: 'member',
+      signInTime: 'linkage-member',
+    });
+    expect(app.acl.getRole('member').getStrategy().allowConfigure).not.toBe(true);
     app.db.collection({
       name: 'popup_staff',
       fields: [
@@ -81,14 +95,41 @@ describe('variables:resolve form grid linkage rules', () => {
     await repository.insertModel({
       uid: formUid,
       use: 'EditFormModel',
+      stepParams: {
+        resourceSettings: {
+          init: {
+            collectionName: 'popup_staff',
+            dataSourceKey: 'main',
+            filterByTk: '{{ ctx.popup.record.id }}',
+          },
+        },
+      },
       subModels: {
         grid: {
           uid: `${formUid}-grid`,
           use: 'FormGridModel',
-          stepParams: { eventSettings: { linkageRules: linkageRules(configured) } },
+          variableContractType: { type: 'formGrid', use: 'FormGridModel' },
         },
       },
     });
+    await repository.insertModel({
+      uid: 'form-event-reference',
+      use: 'ReferenceBlockModel',
+      stepParams: {
+        referenceSettings: { target: { targetUid: formUid } },
+        instanceEvent: { configure: { value: '{{ ctx.popup.record.staffname }}' } },
+      },
+    });
+    const grid = await repository.findModelById(`${formUid}-grid`);
+    const saved = await app
+      .agent()
+      .post('/api/flowModels:save')
+      .auth(rootToken, { type: 'bearer' })
+      .set('X-Authenticator', 'basic')
+      .set('X-Role', 'root')
+      .send({ ...grid, stepParams: { eventSettings: { linkageRules: linkageRules(configured) } } });
+    expect(saved.status).toBe(200);
+
     for (const legacy of [false, true]) {
       const hostUid = legacy ? 'legacy-reference-form' : 'reference-form';
       const targetUid = `${hostUid}-template`;
@@ -126,34 +167,27 @@ describe('variables:resolve form grid linkage rules', () => {
   it.each([formUid, 'reference-form', 'legacy-reference-form'])(
     'resolves configured popup fields for member from %s without allowing unconfigured fields',
     async (modelUid) => {
-      const signInTime = 'form-linkage-test';
-      const payload = Buffer.from(JSON.stringify({ userId: 1, signInTime })).toString('base64url');
-      const token = `test.${payload}.sig`;
-      const rd = generateFlowModelRd(modelUid, `1:${signInTime}`);
-      const values = {
-        batch: [configured, unconfigured].map((value, id) => ({
-          id,
-          rd,
-          template: linkageRules(value),
-          contextParams: { 'popup.record': { collection: 'popup_staff', dataSourceKey: 'main', filterByTk } },
-        })),
-      };
-      const action = app.resourceManager.getAction('variables', 'resolve').clone();
-      action.mergeParams({ values });
-      const ctx = {
-        app,
-        db: app.db,
-        action,
-        auth: { user: { id: 1 }, role: 'member' },
-        state: { currentRole: 'member', currentRoles: ['member'] },
-        get: (name: string) => (name.toLowerCase() === 'authorization' ? `Bearer ${token}` : ''),
-        getCurrentLocale: () => 'en-US',
-        request: { method: 'POST', path: '/api/variables:resolve', query: {}, body: values },
-      } as unknown as ResourcerContext;
+      const response = await app
+        .agent()
+        .post('/api/variables:resolve')
+        .auth(memberToken, { type: 'bearer' })
+        .set('X-Authenticator', 'basic')
+        .set('X-Role', 'member')
+        .send({
+          values: {
+            batch: [configured, unconfigured].map((value, id) => ({
+              id,
+              rd: generateFlowModelRdFromToken(modelUid, memberToken),
+              template: linkageRules(value),
+              contextParams: {
+                'popup.record': { collection: 'popup_staff', dataSourceKey: 'main', filterByTk: String(filterByTk) },
+              },
+            })),
+          },
+        });
+      expect(response.status).toBe(200);
 
-      await action.execute(ctx, async () => {});
-
-      expect(ctx.body).toEqual({
+      expect(response.body.data).toEqual({
         results: [
           { id: 0, data: linkageRules('STAFF-001') },
           { id: 1, data: linkageRules(unconfigured) },
@@ -161,4 +195,69 @@ describe('variables:resolve form grid linkage rules', () => {
       });
     },
   );
+
+  it('keeps administrator popup resolution working through HTTP', async () => {
+    const response = await app
+      .agent()
+      .post('/api/variables:resolve')
+      .auth(rootToken, { type: 'bearer' })
+      .set('X-Authenticator', 'basic')
+      .set('X-Role', 'root')
+      .send({
+        values: {
+          batch: [
+            {
+              id: 'root',
+              rd: generateFlowModelRdFromToken(formUid, rootToken),
+              template: linkageRules(configured),
+              contextParams: {
+                'popup.record': { collection: 'popup_staff', dataSourceKey: 'main', filterByTk: String(filterByTk) },
+              },
+            },
+          ],
+        },
+      });
+    expect(response.status).toBe(200);
+    expect(response.body.data.results).toEqual([{ id: 'root', data: linkageRules('STAFF-001') }]);
+  });
+
+  it('preserves both instance and target form variables in forwarded reference events', async () => {
+    const template = {
+      instance: '{{ ctx.popup.record.staffname }}',
+      form: '{{ ctx.popup.record.id }}',
+      grid: '{{ ctx.popup.record.staffseq }}',
+    };
+    const response = await app
+      .agent()
+      .post('/api/variables:resolve')
+      .auth(memberToken, { type: 'bearer' })
+      .set('X-Authenticator', 'basic')
+      .set('X-Role', 'member')
+      .send({
+        values: {
+          batch: [
+            {
+              id: 'reference',
+              rd: generateFlowModelRdFromToken(formUid, memberToken),
+              contractRd: generateFlowModelRdFromToken('form-event-reference', memberToken),
+              template,
+              contextParams: {
+                'popup.record': { collection: 'popup_staff', dataSourceKey: 'main', filterByTk: String(filterByTk) },
+              },
+            },
+          ],
+        },
+      });
+    expect(response.status).toBe(200);
+    expect(response.body.data.results).toEqual([
+      {
+        id: 'reference',
+        data: {
+          instance: 'Example',
+          form: filterByTk,
+          grid: 'STAFF-001',
+        },
+      },
+    ]);
+  });
 });

--- a/packages/plugins/@nocobase/plugin-flow-engine/src/server/__tests__/variables.resolve.form-linkage.test.ts
+++ b/packages/plugins/@nocobase/plugin-flow-engine/src/server/__tests__/variables.resolve.form-linkage.test.ts
@@ -318,7 +318,7 @@ describe('variables:resolve form grid linkage rules', () => {
     async (name, count, length) => {
       const modelUid = 'event-budget-' + name;
       const independent = '{{ ctx.popup.record.id }}';
-      const code = ("const value = '" + unconfigured + "';").padEnd(length);
+      const code = ("const value = '" + configured + "';").padEnd(length);
       const steps = Object.fromEntries(
         Array.from({ length: count }, (_, index) => [
           'script' + index,
@@ -351,7 +351,7 @@ describe('variables:resolve form grid linkage rules', () => {
         .set('X-Role', 'member')
         .send({
           values: {
-            batch: [independent, unconfigured].map((template, id) => ({
+            batch: [independent, configured, unconfigured].map((template, id) => ({
               id,
               rd: generateFlowModelRdFromToken(modelUid, memberToken),
               template,
@@ -364,7 +364,8 @@ describe('variables:resolve form grid linkage rules', () => {
       expect(response.status).toBe(200);
       expect(response.body.data.results).toEqual([
         { id: 0, data: filterByTk },
-        { id: 1, data: unconfigured },
+        { id: 1, data: 'STAFF-001' },
+        { id: 2, data: unconfigured },
       ]);
     },
   );

--- a/packages/plugins/@nocobase/plugin-flow-engine/src/server/__tests__/variables.resolve.form-linkage.test.ts
+++ b/packages/plugins/@nocobase/plugin-flow-engine/src/server/__tests__/variables.resolve.form-linkage.test.ts
@@ -9,6 +9,11 @@
 
 import type { MockServer } from '@nocobase/test';
 import { generateFlowModelRdFromToken } from '@nocobase/utils';
+import {
+  MAX_RUNJS_SOURCES_PER_REQUEST,
+  MAX_RUNJS_SOURCE_LENGTH,
+  MAX_RUNJS_TOTAL_SOURCE_LENGTH,
+} from '../flow-surfaces/runjs-authoring/runtime/constants';
 import type FlowModelRepository from '../repository';
 import { createFlowEngineMockServer, resetVariablesRegistryForTest } from './test-utils';
 
@@ -193,6 +198,110 @@ describe('variables:resolve form grid linkage rules', () => {
           { id: 1, data: linkageRules(unconfigured) },
         ],
       });
+    },
+  );
+
+  it.each(['option', 'events'])('resolves member variables in a saved 70 KiB chart %s script', async (source) => {
+    const modelUid = 'large-chart-' + source;
+    const independent = '{{ ctx.popup.record.id }}';
+    const code = ('// ' + unconfigured + "\nconst value = '" + configured + "';").padEnd(70 * 1024);
+    const saved = await app
+      .agent()
+      .post('/api/flowModels:save')
+      .auth(rootToken, { type: 'bearer' })
+      .set('X-Authenticator', 'basic')
+      .set('X-Role', 'root')
+      .send({
+        uid: modelUid,
+        use: 'ChartBlockModel',
+        props: { value: independent },
+        stepParams: { chartSettings: { configure: { chart: { [source]: { raw: code } } } } },
+      });
+    expect(saved.status).toBe(200);
+
+    const response = await app
+      .agent()
+      .post('/api/variables:resolve')
+      .auth(memberToken, { type: 'bearer' })
+      .set('X-Authenticator', 'basic')
+      .set('X-Role', 'member')
+      .send({
+        values: {
+          batch: [independent, configured, unconfigured].map((template, id) => ({
+            id,
+            rd: generateFlowModelRdFromToken(modelUid, memberToken),
+            template,
+            contextParams: {
+              'popup.record': { collection: 'popup_staff', dataSourceKey: 'main', filterByTk: String(filterByTk) },
+            },
+          })),
+        },
+      });
+    expect(response.status).toBe(200);
+    expect(response.body.data.results).toEqual([
+      { id: 0, data: filterByTk },
+      { id: 1, data: 'STAFF-001' },
+      { id: 2, data: unconfigured },
+    ]);
+  });
+
+  it.each([
+    ['single-source', 1, MAX_RUNJS_SOURCE_LENGTH + 1],
+    ['source-count', MAX_RUNJS_SOURCES_PER_REQUEST + 1, 100],
+    ['total-length', 5, Math.floor(MAX_RUNJS_TOTAL_SOURCE_LENGTH / 5) + 1],
+  ])(
+    'resolves independent member variables when saved event scripts exceed the %s AST budget',
+    async (name, count, length) => {
+      const modelUid = 'event-budget-' + name;
+      const independent = '{{ ctx.popup.record.id }}';
+      const code = ("const value = '" + unconfigured + "';").padEnd(length);
+      const steps = Object.fromEntries(
+        Array.from({ length: count }, (_, index) => [
+          'script' + index,
+          { use: 'runjs', defaultParams: { code, version: 'v2' } },
+        ]),
+      );
+      const saved = await app
+        .agent()
+        .post('/api/flowModels:save')
+        .auth(rootToken, { type: 'bearer' })
+        .set('X-Authenticator', 'basic')
+        .set('X-Role', 'root')
+        .send({
+          uid: modelUid,
+          use: 'EditFormModel',
+          flowRegistry: { custom: { on: { eventName: 'beforeRender' }, steps } },
+          stepParams: {
+            resourceSettings: {
+              init: { collectionName: 'popup_staff', dataSourceKey: 'main', filterByTk: independent },
+            },
+          },
+        });
+      expect(saved.status).toBe(200);
+
+      const response = await app
+        .agent()
+        .post('/api/variables:resolve')
+        .auth(memberToken, { type: 'bearer' })
+        .set('X-Authenticator', 'basic')
+        .set('X-Role', 'member')
+        .send({
+          values: {
+            batch: [independent, unconfigured].map((template, id) => ({
+              id,
+              rd: generateFlowModelRdFromToken(modelUid, memberToken),
+              template,
+              contextParams: {
+                'popup.record': { collection: 'popup_staff', dataSourceKey: 'main', filterByTk: String(filterByTk) },
+              },
+            })),
+          },
+        });
+      expect(response.status).toBe(200);
+      expect(response.body.data.results).toEqual([
+        { id: 0, data: filterByTk },
+        { id: 1, data: unconfigured },
+      ]);
     },
   );
 

--- a/packages/plugins/@nocobase/plugin-flow-engine/src/server/__tests__/variables.resolve.form-linkage.test.ts
+++ b/packages/plugins/@nocobase/plugin-flow-engine/src/server/__tests__/variables.resolve.form-linkage.test.ts
@@ -265,6 +265,52 @@ describe('variables:resolve form grid linkage rules', () => {
     }
   });
 
+  it.each([
+    ['block', "if (true) /[/*]/.test('/');\n"],
+    ['line', "if (true) /[//]/.test('/'); "],
+  ])('resolves member filter defaults after a regex containing a %s comment marker', async (name, prefix) => {
+    const modelUid = 'filter-regex-' + name;
+    const code =
+      prefix +
+      `const templates = { value: '${configured}' }; return ctx.resolveJsonTemplate(templates.value);\n// ${unconfigured}`;
+    const saved = await app
+      .agent()
+      .post('/api/flowModels:save')
+      .auth(rootToken, { type: 'bearer' })
+      .set('X-Authenticator', 'basic')
+      .set('X-Role', 'root')
+      .send({
+        uid: modelUid,
+        use: 'FilterFormBlockModel',
+        stepParams: {
+          formFilterBlockModelSettings: { defaultValues: { value: [{ value: { code, version: 'v2' } }] } },
+        },
+      });
+    expect(saved.status).toBe(200);
+
+    const response = await app
+      .agent()
+      .post('/api/variables:resolve')
+      .auth(memberToken, { type: 'bearer' })
+      .set('X-Authenticator', 'basic')
+      .set('X-Role', 'member')
+      .send({
+        values: {
+          batch: [configured, unconfigured].map((template, id) => ({
+            id,
+            rd: generateFlowModelRdFromToken(modelUid, memberToken),
+            template,
+            contextParams: { 'popup.record': { collection: 'popup_staff', filterByTk } },
+          })),
+        },
+      });
+    expect(response.status).toBe(200);
+    expect(response.body.data.results).toEqual([
+      { id: 0, data: 'STAFF-001' },
+      { id: 1, data: unconfigured },
+    ]);
+  });
+
   it.each(['option', 'events'])('resolves member variables in a saved 70 KiB chart %s script', async (source) => {
     const modelUid = 'large-chart-' + source;
     const independent = '{{ ctx.popup.record.id }}';

--- a/packages/plugins/@nocobase/plugin-flow-engine/src/server/__tests__/variables.resolve.form-linkage.test.ts
+++ b/packages/plugins/@nocobase/plugin-flow-engine/src/server/__tests__/variables.resolve.form-linkage.test.ts
@@ -268,6 +268,19 @@ describe('variables:resolve form grid linkage rules', () => {
   it.each([
     ['block', "if (true) /[/*]/.test('/');\n"],
     ['line', "if (true) /[//]/.test('/'); "],
+    ['after-block', "if (true) {} /[/*]/.test('/');\n"],
+    ['after-function', "function noop() {} /[//]/.test('/'); "],
+    ['after-class', "class Noop {} /[/*]/.test('/'); "],
+    ['after-finally', "try {} finally {} /[//]/.test('/'); "],
+    ['await', 'await /[//]/; '],
+    ['CR', '// hidden\r'],
+    ['LS', '// hidden\u2028'],
+    ['PS', '// hidden\u2029'],
+    ['bare-template', 'const id = {{ ctx.popup.record.staffseq }}; '],
+    [
+      'template-expression',
+      'const text = `${(() => { if (true) /[/*]/.test("/"); return "x"; })()} // {{ ctx.popup.record.staffseq }}`; ',
+    ],
   ])('resolves member filter defaults after a regex containing a %s comment marker', async (name, prefix) => {
     const modelUid = 'filter-regex-' + name;
     const code =
@@ -314,7 +327,9 @@ describe('variables:resolve form grid linkage rules', () => {
   it.each(['option', 'events'])('resolves member variables in a saved 70 KiB chart %s script', async (source) => {
     const modelUid = 'large-chart-' + source;
     const independent = '{{ ctx.popup.record.id }}';
-    const code = ('// ' + unconfigured + "\nconst value = '" + configured + "';").padEnd(70 * 1024);
+    const code = ('// ' + unconfigured + "\nif (true) {} /[/*]/.test('/'); const value = '" + configured + "';").padEnd(
+      70 * 1024,
+    );
     const saved = await app
       .agent()
       .post('/api/flowModels:save')

--- a/packages/plugins/@nocobase/plugin-flow-engine/src/server/__tests__/variables.runjs-dependencies.test.ts
+++ b/packages/plugins/@nocobase/plugin-flow-engine/src/server/__tests__/variables.runjs-dependencies.test.ts
@@ -367,4 +367,102 @@ describe('persisted RunJS variable dependencies', () => {
       expect(prepareFlowModelVariableSource(value)).toEqual({ ok: false });
     }
   });
+
+  it.each(['dynamic', 'defaultParams', 'linkageScript', 'linkageValue', 'filterValue', 'chartOption', 'chartEvents'])(
+    'collects static dependencies from %s without executing scripts',
+    (scene) => {
+      const code = "await ctx.getVar('ctx.popup.record.name');";
+      const runJsValue = { code, version: 'v2' };
+      let source: unknown;
+      if (scene === 'dynamic' || scene === 'defaultParams') {
+        source = {
+          flowRegistry: {
+            custom: {
+              steps: {
+                customStep: {
+                  use: 'runjs',
+                  ...(scene === 'defaultParams' ? { defaultParams: runJsValue } : {}),
+                },
+              },
+            },
+          },
+          stepParams: { custom: { customStep: scene === 'dynamic' ? runJsValue : {} } },
+        };
+      } else if (scene === 'linkageScript' || scene === 'linkageValue') {
+        source = {
+          stepParams: {
+            eventSettings: {
+              linkageRules: {
+                value: [
+                  {
+                    actions: [
+                      {
+                        name: scene === 'linkageScript' ? 'linkageRunjs' : 'linkageAssignField',
+                        params: { value: scene === 'linkageScript' ? { script: code } : [{ value: runJsValue }] },
+                      },
+                    ],
+                  },
+                ],
+              },
+            },
+          },
+        };
+      } else if (scene === 'filterValue') {
+        source = {
+          stepParams: { formFilterBlockModelSettings: { defaultValues: { value: [{ value: runJsValue }] } } },
+        };
+      } else {
+        source = {
+          stepParams: {
+            chartSettings: {
+              configure: {
+                chart: {
+                  [scene === 'chartOption' ? 'option' : 'events']: { raw: code },
+                },
+              },
+            },
+          },
+        };
+      }
+      expect(collectPersistedRunJsVariableTemplates([source])).toEqual(['{{ ctx.popup.record.name }}']);
+    },
+  );
+
+  it('does not treat an unrelated custom action code parameter as RunJS', () => {
+    expect(
+      collectPersistedRunJsVariableTemplates({
+        flowRegistry: { custom: { steps: { customStep: { use: 'otherAction' } } } },
+        stepParams: { custom: { customStep: { code: "await ctx.getVar('ctx.popup.record.secret');" } } },
+      }),
+    ).toEqual([]);
+  });
+
+  it('applies the existing script budget and comment masking to linkage strings', () => {
+    const source = (script: string) => ({
+      stepParams: {
+        eventSettings: {
+          linkageRules: {
+            value: [
+              {
+                actions: [
+                  {
+                    name: 'linkageRunjs',
+                    params: { value: { script } },
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      },
+    });
+    expect(prepareFlowModelVariableSource(source(' '.repeat(MAX_RUNJS_SOURCE_LENGTH + 1)))).toEqual({ ok: false });
+    const prepared = prepareFlowModelVariableSource(
+      source("// {{ ctx.user.password }}\nawait ctx.getVar('ctx.user.id');"),
+    );
+    expect(prepared.ok).toBe(true);
+    if (!prepared.ok) return;
+    expect(prepared.runJsTemplates).toEqual(['{{ ctx.user.id }}']);
+    expect(analyzeVariableTemplate(prepared.templateSource, { mode: 'flow-model' }).paths).toEqual([]);
+  });
 });

--- a/packages/plugins/@nocobase/plugin-flow-engine/src/server/__tests__/variables.runjs-dependencies.test.ts
+++ b/packages/plugins/@nocobase/plugin-flow-engine/src/server/__tests__/variables.runjs-dependencies.test.ts
@@ -68,7 +68,14 @@ describe('persisted RunJS variable dependencies', () => {
   });
 
   it.each([
-    ['dynamic identifier', `const template = '{{ ctx.user.id }}'; await ctx.resolveJsonTemplate(template);`],
+    ['mutable identifier', `let template = '{{ ctx.user.id }}'; await ctx.resolveJsonTemplate(template);`],
+    ['dynamic identifier', `const template = getTemplate(); await ctx.resolveJsonTemplate(template);`],
+    ['shadowed identifier', `const template = '{{ ctx.user.id }}'; (template) => ctx.resolveJsonTemplate(template);`],
+    ['out-of-scope identifier', `{ const template = '{{ ctx.user.id }}'; } ctx.resolveJsonTemplate(template);`],
+    ['uninitialized identifier', `ctx.resolveJsonTemplate(template); const template = '{{ ctx.user.id }}';`],
+    ['changed contract', `ctx.resolveJsonTemplate('{{ ctx.user.id }}', { contractModelUid: 'other' });`],
+    ['dynamic options', `ctx.resolveJsonTemplate('{{ ctx.user.id }}', options);`],
+    ['spread options', `ctx.resolveJsonTemplate('{{ ctx.user.id }}', { ...options });`],
     ['call result', `await ctx.resolveJsonTemplate(createTemplate('{{ ctx.user.id }}'));`],
     ['shadowed ctx', `(ctx) => ctx.resolveJsonTemplate('{{ ctx.user.id }}');`],
     ['comment', `// ctx.resolveJsonTemplate('{{ ctx.user.id }}')`],
@@ -81,6 +88,14 @@ describe('persisted RunJS variable dependencies', () => {
     ['array hole', `await ctx.resolveJsonTemplate(['{{ ctx.user.id }}', ,]);`],
   ])('does not collect ctx.resolveJsonTemplate dependencies from a %s', (_title, code) => {
     expect(collectPersistedRunJsVariableTemplates(createRunJsOptions(code))).toEqual([]);
+  });
+
+  it.each([
+    `const template = '{{ ctx.user.id }}'; return ctx.resolveJsonTemplate(template);`,
+    `return ctx.resolveJsonTemplate('{{ ctx.user.id }}', {});`,
+    `const template = '{{ ctx.user.id }}'; return ctx.resolveJsonTemplate(template, {});`,
+  ])('collects explicit template dependencies with static bindings or empty options: %s', (code) => {
+    expect(collectPersistedRunJsVariableTemplates(createRunJsOptions(code))).toEqual(['{{ ctx.user.id }}']);
   });
 
   it.each([

--- a/packages/plugins/@nocobase/plugin-flow-engine/src/server/__tests__/variables.runjs-dependencies.test.ts
+++ b/packages/plugins/@nocobase/plugin-flow-engine/src/server/__tests__/variables.runjs-dependencies.test.ts
@@ -7,6 +7,7 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
+import { maskJavaScriptComments } from '../flow-surfaces/runjs-authoring/ast/source';
 import {
   MAX_RUNJS_SOURCES_PER_REQUEST,
   MAX_RUNJS_SOURCE_LENGTH,
@@ -33,6 +34,27 @@ function createRunJsOptions(code: string, version: string | null = 'v2', setting
 }
 
 describe('persisted RunJS variable dependencies', () => {
+  it.each([
+    "if (true) /[/*]/.test('/');",
+    "if ((value === ')')) /[//]/.test('/');",
+    "while (false) /[/*]/.test('/');",
+    "for (; false;) /[//]/.test('/');",
+    "for await (const value of []) /[//]/.test('/');",
+    "if (true) /* hidden */ /[/*]/.test('/');",
+    'result() / 2;',
+    '(value) / 2;',
+    'object.if() / 2;',
+    'object?.while() / 2;',
+  ])('masks only real comments after statement regexes or division: %s', (prefix) => {
+    const code = `${prefix} const template = '{{ ctx.popup.record.name }}'; // {{ ctx.user.password }}\r\n`;
+    const masked = maskJavaScriptComments(code);
+    expect(masked).toContain("const template = '{{ ctx.popup.record.name }}';");
+    expect(masked).not.toContain('{{ ctx.user.password }}');
+    expect(masked).not.toContain('hidden');
+    expect(masked).toHaveLength(code.length);
+    expect(masked.endsWith('\r\n')).toBe(true);
+  });
+
   it.each([
     ['stepParams', ''],
     ['defaultParams', ''],
@@ -588,11 +610,19 @@ describe('persisted RunJS variable dependencies', () => {
     expect(collectPersistedRunJsVariableTemplates(source)).toContain('{{ ctx.popup.record.name }}');
   });
 
-  it.each([0, MAX_RUNJS_SOURCE_LENGTH + 1])('preserves member templates at script length %s', (length) => {
-    const code =
-      "// {{ ctx.user.password }}\nconst templates = { name: '{{ ctx.popup.record.name }}' }; return ctx.resolveJsonTemplate(templates.name);".padEnd(
-        length,
-      );
+  it.each([
+    [0, ''],
+    [MAX_RUNJS_SOURCE_LENGTH + 1, ''],
+    [0, "if (true) /[/*]/.test('/');\n"],
+    [MAX_RUNJS_SOURCE_LENGTH + 1, "if (true) /[/*]/.test('/');\n"],
+    [0, "if (true) /[//]/.test('/'); "],
+    [MAX_RUNJS_SOURCE_LENGTH + 1, "if (true) /[//]/.test('/'); "],
+  ])('preserves member templates at script length %s after %s', (length, prefix) => {
+    const code = (
+      '// {{ ctx.user.password }}\n' +
+      prefix +
+      "const templates = { name: '{{ ctx.popup.record.name }}' }; return ctx.resolveJsonTemplate(templates.name);"
+    ).padEnd(length);
     const prepared = prepareFlowModelVariableSource({
       stepParams: { formFilterBlockModelSettings: { defaultValues: { value: [{ value: { code, version: 'v2' } }] } } },
     });

--- a/packages/plugins/@nocobase/plugin-flow-engine/src/server/__tests__/variables.runjs-dependencies.test.ts
+++ b/packages/plugins/@nocobase/plugin-flow-engine/src/server/__tests__/variables.runjs-dependencies.test.ts
@@ -33,6 +33,32 @@ function createRunJsOptions(code: string, version: string | null = 'v2', setting
 }
 
 describe('persisted RunJS variable dependencies', () => {
+  it.each([
+    ['stepParams', ''],
+    ['defaultParams', ''],
+    ['stepParams', 'await /[//]/; '],
+  ])('preserves JSX templates while masking real comments in event %s with prefix %s', (location, prefix) => {
+    const code =
+      prefix +
+      "ctx.message.info(<span>https://example.com {'{{ ctx.popup.record.name }}'}{/* {{ ctx.popup.record.secret }} */}</span>); // {{ ctx.user.password }}";
+    const source = {
+      flowRegistry: {
+        custom: {
+          steps: { script: { use: 'runjs', ...(location === 'defaultParams' ? { defaultParams: { code } } : {}) } },
+        },
+      },
+      ...(location === 'stepParams' ? { stepParams: { custom: { script: { code } } } } : {}),
+    };
+    const prepared = prepareFlowModelVariableSource(source);
+    expect(prepared.ok).toBe(true);
+    if (!prepared.ok) return;
+    expect(
+      analyzeVariableTemplate([prepared.templateSource, ...prepared.runJsTemplates], {
+        mode: 'flow-model',
+      }).paths.map((path) => path.runtimeKey),
+    ).toEqual([JSON.stringify(['popup', 'record', 'name'])]);
+  });
+
   it('collects direct unshadowed ctx.getVar calls from nested RunJS values', () => {
     const templates = collectPersistedRunJsVariableTemplates({
       stepParams: {

--- a/packages/plugins/@nocobase/plugin-flow-engine/src/server/__tests__/variables.runjs-dependencies.test.ts
+++ b/packages/plugins/@nocobase/plugin-flow-engine/src/server/__tests__/variables.runjs-dependencies.test.ts
@@ -9,6 +9,7 @@
 
 import { maskJavaScriptComments } from '../flow-surfaces/runjs-authoring/ast/source';
 import * as runJsParser from '../flow-surfaces/runjs-authoring/ast/parser';
+import * as runJsBindings from '../flow-surfaces/runjs-authoring/ast/static-bindings';
 import {
   MAX_RUNJS_SOURCES_PER_REQUEST,
   MAX_RUNJS_SOURCE_LENGTH,
@@ -55,6 +56,25 @@ const commentSyntaxCases = [
 ] as const;
 
 describe('persisted RunJS variable dependencies', () => {
+  it.each(['v1', null])('preserves version %s templates in the runtime new.target scope', (version) => {
+    const prefix = '// {{ ctx.user.password }}\r\n';
+    const code = `${prefix}return new.target || '{{ ctx.popup.record.name }}'; // {{ ctx.user.token }}`;
+    const prepared = prepareFlowModelVariableSource(createRunJsOptions(code, version));
+    expect(prepared.ok).toBe(true);
+    if (!prepared.ok) return;
+    expect(analyzeVariableTemplate(prepared.templateSource).paths.map((path) => path.runtimeKey)).toEqual([
+      JSON.stringify(['popup', 'record', 'name']),
+    ]);
+    const masked = maskJavaScriptComments(code);
+    expect(masked).toHaveLength(code.length);
+    expect(masked.indexOf('return')).toBe(prefix.length);
+    expect(masked).not.toMatch(/password|token/);
+    expect(runJsParser.parseRunJsAuthoringAst(code).error).toBeDefined();
+    expect(maskJavaScriptComments(`${code}\nconst invalid = ;`)).toBe('');
+    expect(maskJavaScriptComments(`super(); ${code}`)).toBe('');
+    expect(maskJavaScriptComments(`return new.other || '{{ ctx.popup.record.name }}';`)).toBe('');
+  });
+
   it.each(commentSyntaxCases)(
     'preserves templates after %s syntax, including beyond the inference limit',
     (_name, prefix) => {
@@ -413,6 +433,93 @@ describe('persisted RunJS variable dependencies', () => {
     expect(analyzeVariableTemplate(prepared.templateSource).paths.map((path) => path.runtimeKey)).toEqual([
       JSON.stringify(['record', 'id']),
     ]);
+  });
+
+  it.each([
+    "return ctx.getVar('ctx.popup.record.name');",
+    "return ctx.resolveJsonTemplate('{{ ctx.popup.record.name }}');",
+  ])('skips binding expansion for direct variable calls: %s', (call) => {
+    const collectStrings = vi.spyOn(runJsBindings, 'collectStaticStringBindingsFromAst');
+    const collectValues = vi.spyOn(runJsBindings, 'collectStaticFilterValueBindingsFromAst');
+    const declarations = Array.from({ length: 1000 }, (_, index) => `const a${index} = object;`).join('\n');
+    try {
+      const code = `const object = { a: 'a', b: 'b' };\n${declarations}\n${call}`;
+      expect(collectPersistedRunJsVariableTemplates(createRunJsOptions(code))).toEqual(['{{ ctx.popup.record.name }}']);
+      expect(collectStrings).not.toHaveBeenCalled();
+      expect(collectValues).not.toHaveBeenCalled();
+    } finally {
+      collectStrings.mockRestore();
+      collectValues.mockRestore();
+    }
+  });
+
+  it.each([
+    "const template = '{{ ctx.popup.record.name }}';",
+    "const template = { name: '{{ ctx.popup.record.name }}' };",
+  ])('resolves a template binding without expanding unrelated object aliases: %s', (declaration) => {
+    const properties = Array.from({ length: 500 }, (_, index) => `p${index}: 'v${index}'`).join(',');
+    const aliases = Array.from({ length: 100 }, (_, index) => `const a${index} = palette;`).join('\n');
+    const code = `const palette = {${properties}};\n${aliases}\n${declaration}\nreturn ctx.resolveJsonTemplate(template);`;
+    expect(collectPersistedRunJsVariableTemplates(createRunJsOptions(code))).toEqual(['{{ ctx.popup.record.name }}']);
+  });
+
+  it('bounds connected alias expansion while retaining direct dependencies and other model templates', () => {
+    const aliases = Array.from({ length: 1000 }, (_, index) => `const a${index} = object;`).join('\n');
+    const code = [
+      "const object = { name: '{{ ctx.user.unconfigured }}' };",
+      aliases,
+      'ctx.resolveJsonTemplate(object);',
+      "ctx.resolveJsonTemplate('{{ ctx.popup.record.name }}');",
+      "return ctx.getVar('ctx.user.id');",
+    ].join('\n');
+    const prepared = prepareFlowModelVariableSource({
+      props: { title: '{{ ctx.record.id }}' },
+      ...createRunJsOptions(code),
+      child: createRunJsOptions("return ctx.getVar('ctx.user.name');"),
+    });
+    expect(prepared.ok).toBe(true);
+    if (!prepared.ok) return;
+    expect(prepared.runJsTemplates).toEqual([
+      '{{ ctx.popup.record.name }}',
+      '{{ ctx.user.id }}',
+      '{{ ctx.user.name }}',
+    ]);
+    expect(analyzeVariableTemplate(prepared.templateSource).paths.map((path) => path.runtimeKey)).toEqual([
+      JSON.stringify(['record', 'id']),
+    ]);
+  });
+
+  it.each([
+    [50, 0, 100],
+    [500, 0, 0],
+    [50, 10, 0],
+  ])('resolves literal objects with %i properties, %i aliases and %i unrelated bindings', (size, count, noise) => {
+    const properties = Array.from({ length: size }, (_, index) => `p${index}: '{{ ctx.user.id }}'`).join(',');
+    const aliases = Array.from({ length: count }, (_, index) => `const a${index} = template;`).join('\n');
+    const unrelated = Array.from({ length: noise }, (_, index) => `const b${index} = 0;`).join('\n');
+    const code = `const template = {${properties}};\n${aliases}\n${unrelated}\nctx.resolveJsonTemplate(template);`;
+    expect(collectPersistedRunJsVariableTemplates(createRunJsOptions(code))).toEqual(['{{ ctx.user.id }}']);
+  });
+
+  it.each([
+    "const original = '{{ ctx.user.id }}'; const template = original;",
+    "const source = { name: '{{ ctx.user.id }}' }; const { name: template } = source;",
+    'const source = { name: "{{ ctx.user.id }}" }; const template = `${source.name}`;',
+  ])('follows the requested template binding dependencies: %s', (declarations) => {
+    expect(
+      collectPersistedRunJsVariableTemplates(
+        createRunJsOptions(`${declarations} return ctx.resolveJsonTemplate(template);`),
+      ),
+    ).toEqual(['{{ ctx.user.id }}']);
+  });
+
+  it.each([
+    "const template = { id: '{{ ctx.user.id }}' }; const alias = template; alias.id = value;",
+    "const template = { id: '{{ ctx.user.id }}' }; const alias = template; const other = alias; other.id = value;",
+    "const source = { child: { id: '{{ ctx.user.id }}' } }; const { child: template } = source; const alias = source.child; alias.id = value;",
+  ])('still rejects object dependencies mutated through another alias: %s', (declarations) => {
+    const code = `${declarations} ctx.resolveJsonTemplate(template);`;
+    expect(collectPersistedRunJsVariableTemplates(createRunJsOptions(code))).toEqual([]);
   });
 
   it.each([

--- a/packages/plugins/@nocobase/plugin-flow-engine/src/server/__tests__/variables.runjs-dependencies.test.ts
+++ b/packages/plugins/@nocobase/plugin-flow-engine/src/server/__tests__/variables.runjs-dependencies.test.ts
@@ -84,6 +84,52 @@ describe('persisted RunJS variable dependencies', () => {
     expect(masked).toHaveLength(code.length);
   });
 
+  it.each([
+    '<div>A > B: {name}</div>',
+    '<div>A } B: {name}</div>',
+    '<div>{{ctx.popup.record.name}}</div>',
+    '<div>{...[name]}</div>',
+    '<div>{/* {{ ctx.user.secret }} */ ...[name]}</div>',
+    '<div>A > B\r\n{{ctx.popup.record.name}}\u2028{/* {{ ctx.user.secret }} */}</div>',
+    '<div>A > B: {{ctx.popup.record.name}}{...[name]}{/* {{ ctx.user.secret }} */}</div>',
+  ])('preserves legacy templates in client-compatible JSX: %s', (element) => {
+    const code = [
+      '// {{ ctx.user.password }}',
+      "const name = '{{ ctx.popup.record.name }}';",
+      `ctx.render(${element});`,
+      "if (true) {} /[/*]/.test('/');",
+      '/* {{ ctx.user.token }} */',
+    ].join('\n');
+    const masked = maskJavaScriptComments(code);
+    expect(masked).toHaveLength(code.length);
+    const jsxComment = '/* {{ ctx.user.secret }} */';
+    expect(masked).toContain(element.replace(jsxComment, ' '.repeat(jsxComment.length)));
+    expect(masked).not.toMatch(/password|secret|token/);
+    expect(runJsParser.parseRunJsAuthoringAst(code).error).toBeDefined();
+
+    for (const version of ['v1', null]) {
+      const prepared = prepareFlowModelVariableSource(createRunJsOptions(code, version));
+      expect(prepared.ok).toBe(true);
+      if (!prepared.ok) continue;
+      expect(prepared.runJsTemplates).toEqual([]);
+      expect(
+        new Set(
+          analyzeVariableTemplate(prepared.templateSource, { mode: 'flow-model' }).paths.map((path) => path.runtimeKey),
+        ),
+      ).toEqual(new Set([JSON.stringify(['popup', 'record', 'name'])]));
+    }
+
+    // Compatibility must not turn unrelated syntax errors into trusted variable sources.
+    expect(maskJavaScriptComments(`${code}\nconst broken = ;`)).toBe('');
+  });
+
+  it.each(['const value = `${...items}`;', 'ctx.render(<div title={...items} />);'])(
+    'does not accept spreads outside JSX children in compatibility parsing: %s',
+    (invalid) => {
+      expect(maskJavaScriptComments(`const name = '{{ ctx.user.id }}'; ${invalid}`)).toBe('');
+    },
+  );
+
   it.each(['v1', null])(
     'preserves bare legacy templates in version %s without inferring from substituted values',
     (version) => {
@@ -340,6 +386,33 @@ describe('persisted RunJS variable dependencies', () => {
     `const template = ['{{ ctx.user.id }}']; return ctx.resolveJsonTemplate(template);`,
   ])('collects explicit template dependencies with static bindings or empty options: %s', (code) => {
     expect(collectPersistedRunJsVariableTemplates(createRunJsOptions(code))).toEqual(['{{ ctx.user.id }}']);
+  });
+
+  it('bounds static string expansion without dropping independent variable dependencies', () => {
+    const declarations = ['const s0 = "x";'];
+    for (let index = 1; index <= 29; index += 1) {
+      const previous = `s${index - 1}`;
+      declarations.push(`const s${index} = \`\${${previous}}\${${previous}}\`;`);
+    }
+    const code = [
+      'function unused() {',
+      ...declarations,
+      'ctx.resolveJsonTemplate(s29);',
+      '}',
+      "const template = '{{ ctx.popup.record.name }}';",
+      'ctx.resolveJsonTemplate(template);',
+      "return ctx.getVar('ctx.user.id');",
+    ].join('\n');
+    const prepared = prepareFlowModelVariableSource({
+      props: { title: '{{ ctx.record.id }}' },
+      ...createRunJsOptions(code),
+    });
+    expect(prepared.ok).toBe(true);
+    if (!prepared.ok) return;
+    expect(prepared.runJsTemplates).toEqual(['{{ ctx.popup.record.name }}', '{{ ctx.user.id }}']);
+    expect(analyzeVariableTemplate(prepared.templateSource).paths.map((path) => path.runtimeKey)).toEqual([
+      JSON.stringify(['record', 'id']),
+    ]);
   });
 
   it.each([

--- a/packages/plugins/@nocobase/plugin-flow-engine/src/server/__tests__/variables.runjs-dependencies.test.ts
+++ b/packages/plugins/@nocobase/plugin-flow-engine/src/server/__tests__/variables.runjs-dependencies.test.ts
@@ -76,6 +76,9 @@ describe('persisted RunJS variable dependencies', () => {
     ['changed contract', `ctx.resolveJsonTemplate('{{ ctx.user.id }}', { contractModelUid: 'other' });`],
     ['dynamic options', `ctx.resolveJsonTemplate('{{ ctx.user.id }}', options);`],
     ['spread options', `ctx.resolveJsonTemplate('{{ ctx.user.id }}', { ...options });`],
+    ['shadowed object', `const t = { id: '{{ ctx.user.id }}' }; (t) => ctx.resolveJsonTemplate(t);`],
+    ['mutated object', `const t = { id: '{{ ctx.user.id }}' }; t.id = value; ctx.resolveJsonTemplate(t);`],
+    ['mutated array', `const t = ['{{ ctx.user.id }}']; t[0] = value; ctx.resolveJsonTemplate(t);`],
     ['call result', `await ctx.resolveJsonTemplate(createTemplate('{{ ctx.user.id }}'));`],
     ['shadowed ctx', `(ctx) => ctx.resolveJsonTemplate('{{ ctx.user.id }}');`],
     ['comment', `// ctx.resolveJsonTemplate('{{ ctx.user.id }}')`],
@@ -94,6 +97,8 @@ describe('persisted RunJS variable dependencies', () => {
     `const template = '{{ ctx.user.id }}'; return ctx.resolveJsonTemplate(template);`,
     `return ctx.resolveJsonTemplate('{{ ctx.user.id }}', {});`,
     `const template = '{{ ctx.user.id }}'; return ctx.resolveJsonTemplate(template, {});`,
+    `const template = { id: '{{ ctx.user.id }}' }; return ctx.resolveJsonTemplate(template);`,
+    `const template = ['{{ ctx.user.id }}']; return ctx.resolveJsonTemplate(template);`,
   ])('collects explicit template dependencies with static bindings or empty options: %s', (code) => {
     expect(collectPersistedRunJsVariableTemplates(createRunJsOptions(code))).toEqual(['{{ ctx.user.id }}']);
   });
@@ -496,6 +501,39 @@ describe('persisted RunJS variable dependencies', () => {
         };
       }
       expect(collectPersistedRunJsVariableTemplates([source])).toEqual(['{{ ctx.popup.record.name }}']);
+    },
+  );
+
+  it.each(['filter', 'dynamic', 'defaultParams', 'linkage', 'existing'] as const)(
+    'preserves only legacy template scanning when %s V2 scripts exceed the AST budget',
+    (scene) => {
+      const runJs = {
+        code: (
+          '// {{ ctx.user.password }}\n' + "return ctx.resolveJsonTemplate('{{ ctx.popup.record.name }}');"
+        ).padEnd(MAX_RUNJS_SOURCE_LENGTH + 1),
+        version: 'v2',
+      };
+      const sources = {
+        filter: { stepParams: { formFilterBlockModelSettings: { defaultValues: { value: [{ value: runJs }] } } } },
+        dynamic: {
+          flowRegistry: { custom: { steps: { script: { use: 'runjs' } } } },
+          stepParams: { custom: { script: runJs } },
+        },
+        defaultParams: { flowRegistry: { custom: { steps: { script: { use: 'runjs', defaultParams: runJs } } } } },
+        linkage: {
+          stepParams: {
+            eventSettings: { linkageRules: { value: [{ actions: [{ params: { value: [{ value: runJs }] } }] }] } },
+          },
+        },
+        existing: createRunJsOptions(runJs.code),
+      };
+      const prepared = prepareFlowModelVariableSource(sources[scene]);
+      expect(prepared.ok).toBe(true);
+      if (!prepared.ok) return;
+      expect(prepared.runJsTemplates).toEqual([]);
+      expect(
+        analyzeVariableTemplate(prepared.templateSource, { mode: 'flow-model' }).paths.map((p) => p.runtimeKey),
+      ).toEqual(scene === 'existing' ? [] : [JSON.stringify(['popup', 'record', 'name'])]);
     },
   );
 

--- a/packages/plugins/@nocobase/plugin-flow-engine/src/server/__tests__/variables.runjs-dependencies.test.ts
+++ b/packages/plugins/@nocobase/plugin-flow-engine/src/server/__tests__/variables.runjs-dependencies.test.ts
@@ -221,15 +221,46 @@ describe('persisted RunJS variable dependencies', () => {
     ).toEqual(['{{ ctx.popup.record.name }}']);
   });
 
-  it('fails the whole dependency collection closed when a RunJS source exceeds its limit', () => {
+  it('skips oversized AST sources without losing other RunJS dependencies', () => {
     expect(
       collectPersistedRunJsVariableTemplates({
-        valid: createRunJsOptions(`await ctx.getVar('ctx.user.id');`),
-        oversized: createRunJsOptions(
-          `${' '.repeat(MAX_RUNJS_SOURCE_LENGTH + 1)}await ctx.getVar('ctx.popup.record.name');`,
-        ),
+        valid: createRunJsOptions("await ctx.getVar('ctx.user.id');"),
+        oversized: createRunJsOptions("await ctx.getVar('ctx.popup.record.name');".padEnd(MAX_RUNJS_SOURCE_LENGTH + 1)),
+        later: createRunJsOptions("await ctx.getVar('ctx.view.record.title');"),
       }),
-    ).toEqual([]);
+    ).toEqual(['{{ ctx.user.id }}', '{{ ctx.view.record.title }}']);
+  });
+
+  it('extracts dependencies at the exact AST source length limit', () => {
+    expect(
+      collectPersistedRunJsVariableTemplates(
+        createRunJsOptions("await ctx.getVar('ctx.user.id');".padEnd(MAX_RUNJS_SOURCE_LENGTH)),
+      ),
+    ).toEqual(['{{ ctx.user.id }}']);
+  });
+
+  it.each(['v1', 'v2'])('preserves %s template semantics when a script exceeds the AST limit', (version) => {
+    const code = [
+      '// {{ ctx.user.password }}',
+      "const value = '{{ ctx.popup.record.staffseq }}';",
+      "await ctx.getVar('ctx.view.record.name');",
+    ]
+      .join('\n')
+      .padEnd(MAX_RUNJS_SOURCE_LENGTH + 1);
+    const prepared = prepareFlowModelVariableSource({
+      independent: '{{ ctx.popup.record.id }}',
+      ...createRunJsOptions(code, version),
+    });
+
+    expect(prepared.ok).toBe(true);
+    if (!prepared.ok) return;
+    expect(prepared.runJsTemplates).toEqual([]);
+    expect(
+      analyzeVariableTemplate(prepared.templateSource, { mode: 'flow-model' }).paths.map((path) => path.runtimeKey),
+    ).toEqual([
+      JSON.stringify(['popup', 'record', 'id']),
+      ...(version === 'v1' ? [JSON.stringify(['popup', 'record', 'staffseq'])] : []),
+    ]);
   });
 
   it('screens v2 RunJS code from generic template analysis while preserving static getVar dependencies', () => {
@@ -274,25 +305,50 @@ describe('persisted RunJS variable dependencies', () => {
     ]);
   });
 
-  it('fails closed when the RunJS source count exceeds its aggregate limit', () => {
-    const sources = Object.fromEntries(
-      Array.from({ length: MAX_RUNJS_SOURCES_PER_REQUEST + 1 }, (_, index) => [
-        `source${index}`,
-        createRunJsOptions(''),
-      ]),
+  it('limits the number of AST sources without discarding configured templates', () => {
+    const sources = Array.from({ length: MAX_RUNJS_SOURCES_PER_REQUEST + 1 }, (_, index) =>
+      createRunJsOptions("await ctx.getVar('ctx.record.field" + index + "');"),
     );
+    const prepared = prepareFlowModelVariableSource({ independent: '{{ ctx.user.id }}', sources });
 
-    expect(prepareFlowModelVariableSource(sources)).toEqual({ ok: false });
+    expect(prepared.ok).toBe(true);
+    if (!prepared.ok) return;
+    expect(prepared.runJsTemplates).toHaveLength(MAX_RUNJS_SOURCES_PER_REQUEST);
+    expect(prepared.runJsTemplates).toContain('{{ ctx.record.field99 }}');
+    expect(prepared.runJsTemplates).not.toContain('{{ ctx.record.field100 }}');
+    expect(analyzeVariableTemplate(prepared.templateSource).paths.map((path) => path.runtimeKey)).toEqual([
+      JSON.stringify(['user', 'id']),
+    ]);
   });
 
-  it('fails closed when the aggregate RunJS source length exceeds its limit', () => {
-    const code = ' '.repeat(Math.floor(MAX_RUNJS_TOTAL_SOURCE_LENGTH / 5) + 1);
-    const sources = Object.fromEntries(
-      Array.from({ length: 5 }, (_, index) => [`source${index}`, createRunJsOptions(code)]),
+  it('limits aggregate AST source length without discarding configured templates', () => {
+    const sources = Array.from({ length: MAX_RUNJS_TOTAL_SOURCE_LENGTH / MAX_RUNJS_SOURCE_LENGTH + 1 }, (_, index) =>
+      createRunJsOptions(("await ctx.getVar('ctx.record.field" + index + "');").padEnd(MAX_RUNJS_SOURCE_LENGTH)),
     );
+    const prepared = prepareFlowModelVariableSource({ independent: '{{ ctx.user.id }}', sources });
 
-    expect(code.length).toBeLessThan(MAX_RUNJS_SOURCE_LENGTH);
-    expect(prepareFlowModelVariableSource(sources)).toEqual({ ok: false });
+    expect(prepared.ok).toBe(true);
+    if (!prepared.ok) return;
+    expect(prepared.runJsTemplates).toEqual([
+      '{{ ctx.record.field0 }}',
+      '{{ ctx.record.field1 }}',
+      '{{ ctx.record.field2 }}',
+      '{{ ctx.record.field3 }}',
+    ]);
+    expect(analyzeVariableTemplate(prepared.templateSource).paths.map((path) => path.runtimeKey)).toEqual([
+      JSON.stringify(['user', 'id']),
+    ]);
+  });
+
+  it('still rejects scripts exceeding the model string budget', () => {
+    expect(
+      prepareFlowModelVariableSource(createRunJsOptions(' '.repeat(MAX_FLOW_MODEL_VARIABLE_STRING_LENGTH + 1))),
+    ).toEqual({ ok: false });
+    expect(
+      prepareFlowModelVariableSource(
+        Array.from({ length: 5 }, () => createRunJsOptions(' '.repeat(MAX_FLOW_MODEL_VARIABLE_STRING_LENGTH))),
+      ),
+    ).toEqual({ ok: false });
   });
 
   it('fails closed when a flat ordinary object exceeds the node limit', () => {
@@ -437,7 +493,7 @@ describe('persisted RunJS variable dependencies', () => {
     ).toEqual([]);
   });
 
-  it('applies the existing script budget and comment masking to linkage strings', () => {
+  it('preserves linkage templates and comment masking when the AST budget is exceeded', () => {
     const source = (script: string) => ({
       stepParams: {
         eventSettings: {
@@ -456,13 +512,14 @@ describe('persisted RunJS variable dependencies', () => {
         },
       },
     });
-    expect(prepareFlowModelVariableSource(source(' '.repeat(MAX_RUNJS_SOURCE_LENGTH + 1)))).toEqual({ ok: false });
-    const prepared = prepareFlowModelVariableSource(
-      source("// {{ ctx.user.password }}\nawait ctx.getVar('ctx.user.id');"),
-    );
+    const code =
+      "// {{ ctx.user.password }}\nconst value = '{{ ctx.popup.record.name }}';\nawait ctx.getVar('ctx.user.id');";
+    const prepared = prepareFlowModelVariableSource(source(code.padEnd(MAX_RUNJS_SOURCE_LENGTH + 1)));
     expect(prepared.ok).toBe(true);
     if (!prepared.ok) return;
-    expect(prepared.runJsTemplates).toEqual(['{{ ctx.user.id }}']);
-    expect(analyzeVariableTemplate(prepared.templateSource, { mode: 'flow-model' }).paths).toEqual([]);
+    expect(prepared.runJsTemplates).toEqual([]);
+    expect(
+      analyzeVariableTemplate(prepared.templateSource, { mode: 'flow-model' }).paths.map((path) => path.runtimeKey),
+    ).toEqual([JSON.stringify(['popup', 'record', 'name'])]);
   });
 });

--- a/packages/plugins/@nocobase/plugin-flow-engine/src/server/__tests__/variables.runjs-dependencies.test.ts
+++ b/packages/plugins/@nocobase/plugin-flow-engine/src/server/__tests__/variables.runjs-dependencies.test.ts
@@ -8,6 +8,7 @@
  */
 
 import { maskJavaScriptComments } from '../flow-surfaces/runjs-authoring/ast/source';
+import * as runJsParser from '../flow-surfaces/runjs-authoring/ast/parser';
 import {
   MAX_RUNJS_SOURCES_PER_REQUEST,
   MAX_RUNJS_SOURCE_LENGTH,
@@ -33,7 +34,197 @@ function createRunJsOptions(code: string, version: string | null = 'v2', setting
   };
 }
 
+function createFilterRunJsOptions(code: string) {
+  return {
+    stepParams: { formFilterBlockModelSettings: { defaultValues: { value: [{ value: { code, version: 'v2' } }] } } },
+  };
+}
+
+const commentSyntaxCases = [
+  ['block', "if (true) {} /[/*]/.test('/');"],
+  ['block with line marker', "if (true) {} /[//]/.test('/');"],
+  ['function', "function noop() {} /[/*]/.test('/');"],
+  ['class', "class Noop {} /[//]/.test('/');"],
+  ['finally', "try {} finally {} /[/*]/.test('/');"],
+  ['await', 'await /[//]/;'],
+  ['object division', 'const value = {} / 2;'],
+  ['function expression division', 'const value = function () {} / 2;'],
+  ['CR', '// hidden {{ ctx.user.password }}\r'],
+  ['LS', '// hidden {{ ctx.user.password }}\u2028'],
+  ['PS', '// hidden {{ ctx.user.password }}\u2029'],
+] as const;
+
 describe('persisted RunJS variable dependencies', () => {
+  it.each(commentSyntaxCases)(
+    'preserves templates after %s syntax, including beyond the inference limit',
+    (_name, prefix) => {
+      const code = `${prefix} const templates = { name: '{{ ctx.popup.record.name }}' }; return ctx.resolveJsonTemplate(templates.name); // {{ ctx.user.password }}`;
+      for (const length of [0, MAX_RUNJS_SOURCE_LENGTH + 1]) {
+        const prepared = prepareFlowModelVariableSource(createFilterRunJsOptions(code.padEnd(length)));
+        expect(prepared.ok).toBe(true);
+        if (!prepared.ok) continue;
+        expect(
+          analyzeVariableTemplate([prepared.templateSource, ...prepared.runJsTemplates], {
+            mode: 'flow-model',
+          }).paths.map((path) => path.runtimeKey),
+        ).toEqual([JSON.stringify(['popup', 'record', 'name'])]);
+      }
+    },
+  );
+
+  it('preserves template text and JSX around nested expressions with regexes', () => {
+    const code = [
+      'const value = `${(() => { if (true) /[/*]/.test("/"); return "x"; })()} // {{ ctx.popup.record.name }}`;',
+      "ctx.render(<div style={{ width: '100%' }}>https://example.com {value}{/* {{ ctx.user.password }} */}</div>);",
+    ].join('\n');
+    const masked = maskJavaScriptComments(code);
+    expect(masked).toContain('// {{ ctx.popup.record.name }}');
+    expect(masked).toContain('https://example.com');
+    expect(masked).not.toContain('{{ ctx.user.password }}');
+    expect(masked).toHaveLength(code.length);
+  });
+
+  it.each(['v1', null])(
+    'preserves bare legacy templates in version %s without inferring from substituted values',
+    (version) => {
+      const code = [
+        '// {{ ctx.user.password }}',
+        'const id = {{ctx.user.id}};',
+        'const value = {{ ctx.popup.record["name"] }};',
+        'const multiline = {{\n ctx.record.id\n}};',
+        "if (true) {} /[/*]/.test('/');",
+        "ctx.render(<div style={{ width: '100%' }}>{value}</div>);",
+        "ctx.getVar('ctx.user.unconfigured');",
+      ].join('\n');
+      const prepared = prepareFlowModelVariableSource(createRunJsOptions(code, version));
+      expect(prepared.ok).toBe(true);
+      if (!prepared.ok) return;
+      expect(prepared.runJsTemplates).toEqual([]);
+      expect(
+        analyzeVariableTemplate(prepared.templateSource, { mode: 'flow-model' }).paths.map((path) => path.runtimeKey),
+      ).toEqual([
+        JSON.stringify(['user', 'id']),
+        JSON.stringify(['popup', 'record', 'name']),
+        JSON.stringify(['record', 'id']),
+      ]);
+    },
+  );
+
+  it.each([
+    'const text = "{{ ctx.popup.record.name }} //";',
+    'const expression = /{{ctx.record.id}}/;',
+    'const text = `// {{ ctx.popup.record.name }} ${(() => { if (true) {} /[/*]/; return {{ctx.record.id}}; })()}`;',
+    'ctx.render(<div style={{ width: "100%" }} title="{{ ctx.popup.record.name }} //">https://example.com</div>);',
+  ])('keeps literal boundaries and offsets while parsing bare templates around %s', (literal) => {
+    const comment = '/* {{ ctx.user.password }} */';
+    const code = `const id = {{\r\nctx.user.id\r\n}}; ${literal} ${comment}`;
+    expect(maskJavaScriptComments(code)).toBe(code.slice(0, -comment.length) + ' '.repeat(comment.length));
+    expect(runJsParser.parseRunJsAuthoringAst(code).error).toBeDefined();
+    const compatible = runJsParser.parseRunJsAuthoringAst(code, { allowLegacyTemplates: true });
+    expect(compatible.error).toBeUndefined();
+    expect(compatible.ast).toBeUndefined();
+    expect(compatible.comments).toEqual([{ start: code.length - comment.length, end: code.length }]);
+  });
+
+  it.each(['\n', '\r\n', '\r', '\u2028', '\u2029'])(
+    'preserves source offsets and all %j line terminators in comments',
+    (newline) => {
+      const code = `// secret${newline}/* before${newline}after */ const value = '{{ ctx.user.id }}';`;
+      expect(maskJavaScriptComments(code)).toBe(
+        `         ${newline}         ${newline}         const value = '{{ ctx.user.id }}';`,
+      );
+    },
+  );
+
+  it.each(['/* {{ ctx.user.password }} */', '// {{ ctx.user.password }}\n'])(
+    'masks actual comments inside and after bare template expressions: %s',
+    (comment) => {
+      const trailing = '/* trailing */';
+      const code = `const id = {{ctx.${comment}user.id ${trailing}}};`;
+      const masked = maskJavaScriptComments(code);
+      expect(masked).toHaveLength(code.length);
+      expect(masked).not.toContain('password');
+      expect(masked).not.toContain('trailing');
+      expect(analyzeVariableTemplate(masked).paths.map((path) => path.runtimeKey)).toEqual([
+        JSON.stringify(['user', 'id']),
+      ]);
+    },
+  );
+
+  it('does not scan partially parsed invalid scripts or affect independent configured values', () => {
+    const prepared = prepareFlowModelVariableSource({
+      independent: '{{ ctx.user.id }}',
+      ...createFilterRunJsOptions("const before = '{{ ctx.user.password }}'; const broken = ; // {{ ctx.user.token }}"),
+    });
+    expect(prepared.ok).toBe(true);
+    if (!prepared.ok) return;
+    expect(prepared.runJsTemplates).toEqual([]);
+    expect(analyzeVariableTemplate(prepared.templateSource).paths.map((path) => path.runtimeKey)).toEqual([
+      JSON.stringify(['user', 'id']),
+    ]);
+  });
+
+  it('shares parsing between masking, inference, and repeated sources within one preparation', () => {
+    const parse = vi.spyOn(runJsParser, 'parseRunJsAuthoringAst');
+    try {
+      const code = "const template = '{{ ctx.user.id }}'; ctx.getVar('ctx.popup.record.name');";
+      const source = [createFilterRunJsOptions(code), createRunJsOptions(code, 'v1'), createRunJsOptions(code)];
+      const prepared = prepareFlowModelVariableSource(source);
+      expect(prepared.ok).toBe(true);
+      if (!prepared.ok) return;
+      expect(prepared.runJsTemplates).toEqual(['{{ ctx.popup.record.name }}']);
+      expect(parse).toHaveBeenCalledTimes(1);
+      prepareFlowModelVariableSource(source);
+      expect(parse).toHaveBeenCalledTimes(2);
+    } finally {
+      parse.mockRestore();
+    }
+  });
+
+  it('checks source budgets before parsing and keeps compatibility parsing within the model budget', () => {
+    const parse = vi.spyOn(runJsParser, 'parseRunJsAuthoringAst');
+    try {
+      const code = "if (1 < 2) {} /[/*]/; const value = '{{ ctx.user.id }}';";
+      const oversized = code.padEnd(MAX_RUNJS_SOURCE_LENGTH + 1);
+      prepareFlowModelVariableSource(createRunJsOptions(oversized));
+      expect(parse).not.toHaveBeenCalled();
+      prepareFlowModelVariableSource(createFilterRunJsOptions('if (1 < 2) {}'.padEnd(MAX_RUNJS_SOURCE_LENGTH + 1)));
+      expect(parse).not.toHaveBeenCalled();
+      const prepared = prepareFlowModelVariableSource(createFilterRunJsOptions(oversized));
+      expect(prepared.ok).toBe(true);
+      if (!prepared.ok) return;
+      expect(prepared.runJsTemplates).toEqual([]);
+      expect(analyzeVariableTemplate(prepared.templateSource).paths.map((path) => path.runtimeKey)).toEqual([
+        JSON.stringify(['user', 'id']),
+      ]);
+      expect(parse).toHaveBeenCalledTimes(1);
+      expect(
+        prepareFlowModelVariableSource(
+          createFilterRunJsOptions(code.padEnd(MAX_FLOW_MODEL_VARIABLE_STRING_LENGTH + 1)),
+        ),
+      ).toEqual({ ok: false });
+      expect(parse).toHaveBeenCalledTimes(1);
+    } finally {
+      parse.mockRestore();
+    }
+  });
+
+  it('does not parse supplemental sources without template markers after exhausting the inference count', () => {
+    const parse = vi.spyOn(runJsParser, 'parseRunJsAuthoringAst');
+    try {
+      const source = Array.from({ length: MAX_RUNJS_SOURCES_PER_REQUEST + 1 }, (_, index) =>
+        createFilterRunJsOptions(`if (1 < 2) {} ctx.getVar('ctx.record.field${index}');`),
+      );
+      const prepared = prepareFlowModelVariableSource(source);
+      expect(prepared.ok).toBe(true);
+      if (!prepared.ok) return;
+      expect(prepared.runJsTemplates).toHaveLength(MAX_RUNJS_SOURCES_PER_REQUEST);
+      expect(parse).toHaveBeenCalledTimes(MAX_RUNJS_SOURCES_PER_REQUEST);
+    } finally {
+      parse.mockRestore();
+    }
+  });
+
   it.each([
     "if (true) /[/*]/.test('/');",
     "if ((value === ')')) /[//]/.test('/');",

--- a/packages/plugins/@nocobase/plugin-flow-engine/src/server/__tests__/variables.runjs-dependencies.test.ts
+++ b/packages/plugins/@nocobase/plugin-flow-engine/src/server/__tests__/variables.runjs-dependencies.test.ts
@@ -537,6 +537,48 @@ describe('persisted RunJS variable dependencies', () => {
     },
   );
 
+  it.each(['count', 'length'] as const)('reserves the AST %s budget for existing RunJS paths', (limit) => {
+    const count = limit === 'count' ? MAX_RUNJS_SOURCES_PER_REQUEST : 4;
+    const code = "ctx.getVar('ctx.popup.record.supplemental');";
+    const source = {
+      flowRegistry: {
+        custom: {
+          steps: Object.fromEntries(
+            Array.from({ length: count }, (_, index) => [
+              `step${index}`,
+              {
+                use: 'runjs',
+                defaultParams: {
+                  code: limit === 'length' ? code.padEnd(MAX_RUNJS_SOURCE_LENGTH) : code,
+                  version: 'v2',
+                },
+              },
+            ]),
+          ),
+        },
+      },
+      ...createRunJsOptions("ctx.getVar('ctx.popup.record.name');"),
+    };
+    expect(collectPersistedRunJsVariableTemplates(source)).toContain('{{ ctx.popup.record.name }}');
+  });
+
+  it.each([0, MAX_RUNJS_SOURCE_LENGTH + 1])('preserves member templates at script length %s', (length) => {
+    const code =
+      "// {{ ctx.user.password }}\nconst templates = { name: '{{ ctx.popup.record.name }}' }; return ctx.resolveJsonTemplate(templates.name);".padEnd(
+        length,
+      );
+    const prepared = prepareFlowModelVariableSource({
+      stepParams: { formFilterBlockModelSettings: { defaultValues: { value: [{ value: { code, version: 'v2' } }] } } },
+    });
+    expect(prepared.ok).toBe(true);
+    if (!prepared.ok) return;
+    expect(
+      analyzeVariableTemplate([prepared.templateSource, ...prepared.runJsTemplates], { mode: 'flow-model' }).paths.map(
+        (p) => p.runtimeKey,
+      ),
+    ).toEqual([JSON.stringify(['popup', 'record', 'name'])]);
+  });
+
   it('does not treat an unrelated custom action code parameter as RunJS', () => {
     expect(
       collectPersistedRunJsVariableTemplates({

--- a/packages/plugins/@nocobase/plugin-flow-engine/src/server/flow-surfaces/runjs-authoring/ast/parser.ts
+++ b/packages/plugins/@nocobase/plugin-flow-engine/src/server/flow-surfaces/runjs-authoring/ast/parser.ts
@@ -11,7 +11,7 @@ import * as acorn from 'acorn';
 import jsx from 'acorn-jsx';
 import * as acornWalk from 'acorn-walk';
 
-const AcornParserWithJsx = acorn.Parser.extend(jsx());
+export const AcornParserWithJsx = acorn.Parser.extend(jsx());
 export const ACORN_WALK_BASE = {
   ...(acornWalk as any).base,
   JSXElement(node: any, state: any, callback: any) {

--- a/packages/plugins/@nocobase/plugin-flow-engine/src/server/flow-surfaces/runjs-authoring/ast/parser.ts
+++ b/packages/plugins/@nocobase/plugin-flow-engine/src/server/flow-surfaces/runjs-authoring/ast/parser.ts
@@ -19,16 +19,24 @@ type TokenParser = acorn.Parser & {
   pos: number;
   curLine: number;
   lineStart: number;
+  type: acorn.TokenType;
+  context: { token: string }[];
+  curContext(): { token: string };
   readToken(code: number): void;
-  finishToken(type: acorn.TokenType): void;
+  finishToken(type: acorn.TokenType, value?: string): void;
+  jsx_readToken(): void;
+  jsx_readNewLine(normalizeCRLF: boolean): string;
+  next(): void;
+  parseExpression(...args: unknown[]): acorn.Node;
 };
 
-const AcornParserWithLegacyTemplates = acorn.Parser.extend((Parser) => {
+const AcornParserWithLegacyTemplates = AcornParserWithJsx.extend((Parser) => {
   const Base = Parser as unknown as new (options: acorn.Options, input: string) => TokenParser;
+  const { jsxText } = (Parser as typeof acorn.Parser & { acornJsx: { tokTypes: { jsxText: acorn.TokenType } } })
+    .acornJsx.tokTypes;
   return class extends Base {
-    readToken(code: number) {
-      // Only JavaScript tokens reach this hook; JSX, strings, regexes, and template text keep their own grammar.
-      if (code === 123 && this.input.startsWith('{{', this.pos)) {
+    readLegacyTemplate() {
+      if (this.input.startsWith('{{', this.pos)) {
         const start = this.pos;
         if (/^\s*ctx(?:\.|\?\.|\[)/.test(this.input.slice(start + 2))) {
           let end: number | undefined;
@@ -56,14 +64,42 @@ const AcornParserWithLegacyTemplates = acorn.Parser.extend((Parser) => {
               this.lineStart = start + newline.index + newline[0].length;
             }
             this.pos = end;
-            return this.finishToken(acorn.tokTypes._null);
+            return true;
           }
         }
       }
+      return false;
+    }
+
+    readToken(code: number) {
+      if (code === 123 && !this.curContext().token.startsWith('<') && this.readLegacyTemplate()) {
+        return this.finishToken(acorn.tokTypes._null);
+      }
       return super.readToken(code);
     }
+
+    jsx_readToken() {
+      const start = this.pos;
+      if (!this.readLegacyTemplate()) {
+        // Only comment ranges are used: JSX text may contain raw > and } accepted by the client compiler.
+        while (this.pos < this.input.length && !/[<{]/.test(this.input[this.pos])) {
+          if (/[\r\n\u2028\u2029]/.test(this.input[this.pos])) this.jsx_readNewLine(true);
+          else this.pos += 1;
+        }
+      }
+      if (this.pos > start) return this.finishToken(jsxText, this.input.slice(start, this.pos));
+      return super.jsx_readToken();
+    }
+
+    parseExpression(...args: unknown[]) {
+      // Support spread children without relaxing JavaScript or JSX attribute expressions.
+      if (this.type === acorn.tokTypes.ellipsis && this.context.at(-2)?.token === '<tag>...</tag>') {
+        this.next();
+      }
+      return super.parseExpression(...args);
+    }
   } as unknown as typeof acorn.Parser;
-}, jsx());
+});
 
 export type RunJsParseResult = {
   ast?: acorn.Node;

--- a/packages/plugins/@nocobase/plugin-flow-engine/src/server/flow-surfaces/runjs-authoring/ast/parser.ts
+++ b/packages/plugins/@nocobase/plugin-flow-engine/src/server/flow-surfaces/runjs-authoring/ast/parser.ts
@@ -10,8 +10,67 @@
 import * as acorn from 'acorn';
 import jsx from 'acorn-jsx';
 import * as acornWalk from 'acorn-walk';
+import type { SourceRange } from '../internal-types';
 
 export const AcornParserWithJsx = acorn.Parser.extend(jsx());
+
+// Acorn's public types omit the tokenizer hooks used by parser plugins.
+type TokenParser = acorn.Parser & {
+  pos: number;
+  curLine: number;
+  lineStart: number;
+  readToken(code: number): void;
+  finishToken(type: acorn.TokenType): void;
+};
+
+const AcornParserWithLegacyTemplates = acorn.Parser.extend((Parser) => {
+  const Base = Parser as unknown as new (options: acorn.Options, input: string) => TokenParser;
+  return class extends Base {
+    readToken(code: number) {
+      // Only JavaScript tokens reach this hook; JSX, strings, regexes, and template text keep their own grammar.
+      if (code === 123 && this.input.startsWith('{{', this.pos)) {
+        const start = this.pos;
+        if (/^\s*ctx(?:\.|\?\.|\[)/.test(this.input.slice(start + 2))) {
+          let end: number | undefined;
+          const comments: acorn.Comment[] = [];
+          try {
+            const expression = acorn.parseExpressionAt(this.input, start + 2, {
+              ecmaVersion: 'latest',
+              onComment: comments,
+            });
+            const expressionEnd = Math.max(expression.end, comments.at(-1)?.end || 0);
+            const closing = /^\s*}}/.exec(this.input.slice(expressionEnd));
+            if (closing) end = expressionEnd + closing[0].length;
+          } catch {
+            // Invalid placeholders must still fail the full parse.
+          }
+          if (end !== undefined) {
+            const onComment = this.options.onComment;
+            if (typeof onComment === 'function') {
+              for (const comment of comments) {
+                onComment(comment.type === 'Block', comment.value, comment.start, comment.end);
+              }
+            }
+            for (const newline of this.input.slice(start, end).matchAll(/\r\n?|\n|\u2028|\u2029/g)) {
+              this.curLine += 1;
+              this.lineStart = start + newline.index + newline[0].length;
+            }
+            this.pos = end;
+            return this.finishToken(acorn.tokTypes._null);
+          }
+        }
+      }
+      return super.readToken(code);
+    }
+  } as unknown as typeof acorn.Parser;
+}, jsx());
+
+export type RunJsParseResult = {
+  ast?: acorn.Node;
+  comments?: readonly SourceRange[];
+  error?: { index: number; message: string };
+};
+
 export const ACORN_WALK_BASE = {
   ...(acornWalk as any).base,
   JSXElement(node: any, state: any, callback: any) {
@@ -66,18 +125,35 @@ export const ACORN_WALK_BASE = {
   JSXClosingFragment() {},
 };
 
-export function parseRunJsAuthoringAst(source: string): { ast?: any; error?: { index: number; message: string } } {
+export function parseRunJsAuthoringAst(
+  source: string,
+  options: { allowLegacyTemplates?: boolean } = {},
+): RunJsParseResult {
+  const comments: SourceRange[] = [];
+  const parserOptions: acorn.Options = {
+    allowAwaitOutsideFunction: true,
+    allowReturnOutsideFunction: true,
+    ecmaVersion: 'latest',
+    locations: true,
+    sourceType: 'script',
+    onComment: (_block, _text, start, end) => comments.push({ start, end }),
+  };
   try {
     return {
-      ast: AcornParserWithJsx.parse(source, {
-        allowAwaitOutsideFunction: true,
-        allowReturnOutsideFunction: true,
-        ecmaVersion: 'latest',
-        locations: true,
-        sourceType: 'script',
-      }),
+      ast: AcornParserWithJsx.parse(source, parserOptions),
+      comments,
     };
   } catch (error) {
+    if (options.allowLegacyTemplates && source.includes('{{')) {
+      try {
+        comments.length = 0;
+        AcornParserWithLegacyTemplates.parse(source, parserOptions);
+        // Substituted placeholders are only for locating comments, never for inferring static dependencies.
+        return { comments };
+      } catch {
+        // Discard partial comment ranges: they cannot reliably describe an invalid script.
+      }
+    }
     const acornError = error as Error & { pos?: number };
     return {
       error: {

--- a/packages/plugins/@nocobase/plugin-flow-engine/src/server/flow-surfaces/runjs-authoring/ast/parser.ts
+++ b/packages/plugins/@nocobase/plugin-flow-engine/src/server/flow-surfaces/runjs-authoring/ast/parser.ts
@@ -35,6 +35,11 @@ const AcornParserWithLegacyTemplates = AcornParserWithJsx.extend((Parser) => {
   const { jsxText } = (Parser as typeof acorn.Parser & { acornJsx: { tokTypes: { jsxText: acorn.TokenType } } })
     .acornJsx.tokTypes;
   return class extends Base {
+    get allowNewDotTarget() {
+      // JSRunner executes scripts in a function scope; this fallback only locates legacy template comments.
+      return true;
+    }
+
     readLegacyTemplate() {
       if (this.input.startsWith('{{', this.pos)) {
         const start = this.pos;

--- a/packages/plugins/@nocobase/plugin-flow-engine/src/server/flow-surfaces/runjs-authoring/ast/source.ts
+++ b/packages/plugins/@nocobase/plugin-flow-engine/src/server/flow-surfaces/runjs-authoring/ast/source.ts
@@ -9,7 +9,8 @@
 
 import type { CallArgumentSource, SourceRange } from '../internal-types';
 import { NON_METHOD_CALL_KEYWORDS } from '../runtime/constants';
-import { AcornParserWithJsx } from './parser';
+import { parseRunJsAuthoringAst } from './parser';
+import type { RunJsParseResult } from './parser';
 import { walkAstSimple } from './walk';
 
 type AstNodeWithBodyRange = {
@@ -84,111 +85,19 @@ export function maskJavaScriptSource(source: string) {
   return chars.join('');
 }
 
-export function maskJavaScriptComments(source: string) {
+export function maskJavaScriptComments(
+  source: string,
+  parsed: RunJsParseResult = parseRunJsAuthoringAst(source, { allowLegacyTemplates: true }),
+) {
+  if (!parsed.comments) return '';
+  if (!parsed.comments.length) return source;
   const chars = source.split('');
-  const maskRange = (start: number, end: number) => {
+  for (const { start, end } of parsed.comments) {
     for (let index = start; index < end; index += 1) {
-      if (chars[index] !== '\n' && chars[index] !== '\r') {
-        chars[index] = ' ';
-      }
+      if (!/[\r\n\u2028\u2029]/.test(chars[index])) chars[index] = ' ';
     }
-  };
-  if (source.includes('<')) {
-    try {
-      // JSX text can contain // or /* without starting a JavaScript comment.
-      const comments: SourceRange[] = [];
-      AcornParserWithJsx.parse(source, {
-        allowAwaitOutsideFunction: true,
-        allowReturnOutsideFunction: true,
-        ecmaVersion: 'latest',
-        onComment: (_block, _text, start, end) => comments.push({ start, end }),
-      });
-      comments.forEach(({ start, end }) => maskRange(start, end));
-      return chars.join('');
-    } catch {
-      // Keep the existing scanner for incomplete source fragments.
-    }
-  }
-  const statementParens: boolean[] = [];
-  let statementParenEnd = -1;
-  let index = 0;
-  while (index < source.length) {
-    const char = source[index];
-    const next = source[index + 1];
-    if (char === '/' && next === '/') {
-      const start = index;
-      index += 2;
-      while (index < source.length && source[index] !== '\n') {
-        index += 1;
-      }
-      maskRange(start, index);
-      continue;
-    }
-    if (char === '/' && next === '*') {
-      const start = index;
-      index += 2;
-      while (index < source.length && !(source[index] === '*' && source[index + 1] === '/')) {
-        index += 1;
-      }
-      index = Math.min(source.length, index + 2);
-      maskRange(start, index);
-      continue;
-    }
-    if (char === '`') {
-      index = maskTemplateLiteralComments(source, chars, index);
-      continue;
-    }
-    if (
-      char === '/' &&
-      (isRegexLiteralStart(chars, index) || getPreviousSignificantTokenInfo(chars, index)?.start === statementParenEnd)
-    ) {
-      index = skipRegexLiteral(source, index);
-      continue;
-    }
-    if (char === '"' || char === "'") {
-      index = skipQuotedLiteral(source, index, char);
-      continue;
-    }
-    if (char === '(') {
-      let previous = getPreviousSignificantTokenInfo(chars, index);
-      if (previous?.token === 'await') previous = getPreviousSignificantTokenInfo(chars, previous.start);
-      statementParens.push(
-        !!previous &&
-          ['if', 'for', 'while', 'with', 'switch', 'catch'].includes(previous.token) &&
-          getPreviousSignificantToken(chars, previous.start) !== '.',
-      );
-    } else if (char === ')' && statementParens.pop()) {
-      // A control statement can be followed by a regex literal, unlike a call or parenthesized expression.
-      statementParenEnd = index;
-    }
-    index += 1;
   }
   return chars.join('');
-}
-
-export function maskTemplateLiteralComments(source: string, chars: string[], start: number) {
-  let index = start + 1;
-  while (index < source.length) {
-    if (source[index] === '\\') {
-      index += 2;
-      continue;
-    }
-    if (source[index] === '`') {
-      return index + 1;
-    }
-    if (source[index] === '$' && source[index + 1] === '{') {
-      const expressionStart = index + 2;
-      const expressionEnd = findTemplateExpressionEnd(source, expressionStart);
-      const expressionMasked = maskJavaScriptComments(source.slice(expressionStart, expressionEnd));
-      for (let offset = 0; offset < expressionMasked.length; offset += 1) {
-        chars[expressionStart + offset] = expressionMasked[offset];
-      }
-      index = Math.min(source.length, expressionEnd + 1);
-      continue;
-    }
-    index += 1;
-  }
-  return source.length;
 }
 
 export function maskTemplateLiteral(source: string, chars: string[], start: number) {

--- a/packages/plugins/@nocobase/plugin-flow-engine/src/server/flow-surfaces/runjs-authoring/ast/source.ts
+++ b/packages/plugins/@nocobase/plugin-flow-engine/src/server/flow-surfaces/runjs-authoring/ast/source.ts
@@ -109,6 +109,8 @@ export function maskJavaScriptComments(source: string) {
       // Keep the existing scanner for incomplete source fragments.
     }
   }
+  const statementParens: boolean[] = [];
+  let statementParenEnd = -1;
   let index = 0;
   while (index < source.length) {
     const char = source[index];
@@ -136,13 +138,28 @@ export function maskJavaScriptComments(source: string) {
       index = maskTemplateLiteralComments(source, chars, index);
       continue;
     }
-    if (char === '/' && isRegexLiteralStart(chars, index)) {
+    if (
+      char === '/' &&
+      (isRegexLiteralStart(chars, index) || getPreviousSignificantTokenInfo(chars, index)?.start === statementParenEnd)
+    ) {
       index = skipRegexLiteral(source, index);
       continue;
     }
     if (char === '"' || char === "'") {
       index = skipQuotedLiteral(source, index, char);
       continue;
+    }
+    if (char === '(') {
+      let previous = getPreviousSignificantTokenInfo(chars, index);
+      if (previous?.token === 'await') previous = getPreviousSignificantTokenInfo(chars, previous.start);
+      statementParens.push(
+        !!previous &&
+          ['if', 'for', 'while', 'with', 'switch', 'catch'].includes(previous.token) &&
+          getPreviousSignificantToken(chars, previous.start) !== '.',
+      );
+    } else if (char === ')' && statementParens.pop()) {
+      // A control statement can be followed by a regex literal, unlike a call or parenthesized expression.
+      statementParenEnd = index;
     }
     index += 1;
   }

--- a/packages/plugins/@nocobase/plugin-flow-engine/src/server/flow-surfaces/runjs-authoring/ast/source.ts
+++ b/packages/plugins/@nocobase/plugin-flow-engine/src/server/flow-surfaces/runjs-authoring/ast/source.ts
@@ -9,6 +9,7 @@
 
 import type { CallArgumentSource, SourceRange } from '../internal-types';
 import { NON_METHOD_CALL_KEYWORDS } from '../runtime/constants';
+import { AcornParserWithJsx } from './parser';
 import { walkAstSimple } from './walk';
 
 type AstNodeWithBodyRange = {
@@ -92,6 +93,22 @@ export function maskJavaScriptComments(source: string) {
       }
     }
   };
+  if (source.includes('<')) {
+    try {
+      // JSX text can contain // or /* without starting a JavaScript comment.
+      const comments: SourceRange[] = [];
+      AcornParserWithJsx.parse(source, {
+        allowAwaitOutsideFunction: true,
+        allowReturnOutsideFunction: true,
+        ecmaVersion: 'latest',
+        onComment: (_block, _text, start, end) => comments.push({ start, end }),
+      });
+      comments.forEach(({ start, end }) => maskRange(start, end));
+      return chars.join('');
+    } catch {
+      // Keep the existing scanner for incomplete source fragments.
+    }
+  }
   let index = 0;
   while (index < source.length) {
     const char = source[index];

--- a/packages/plugins/@nocobase/plugin-flow-engine/src/server/flow-surfaces/runjs-authoring/ast/static-bindings.ts
+++ b/packages/plugins/@nocobase/plugin-flow-engine/src/server/flow-surfaces/runjs-authoring/ast/static-bindings.ts
@@ -310,11 +310,19 @@ export function collectStaticStringBindingsFromAst(
   source: string,
   seedStringBindings: StaticStringBinding[] = [],
   identifierBindings: AstIdentifierBinding[] = [],
+  consumeWork?: (work: number) => void,
+  bindingNames?: ReadonlySet<string>,
 ): StaticStringBinding[] {
   const bindings: StaticStringBinding[] = [];
   const availableBindings = [...seedStringBindings];
-  const writes = collectAstStaticBindingWritesFromAst(ast, source, identifierBindings);
-  const aliasCopies = collectAstStaticObjectAliasCopiesFromAst(ast, source, identifierBindings);
+  const writes = collectAstStaticBindingWritesFromAst(ast, source, identifierBindings, consumeWork, bindingNames);
+  const aliasCopies = collectAstStaticObjectAliasCopiesFromAst(
+    ast,
+    source,
+    identifierBindings,
+    consumeWork,
+    bindingNames,
+  );
   const addBinding = (
     name: string,
     value: string,
@@ -323,6 +331,7 @@ export function collectStaticStringBindingsFromAst(
     declarationStart: number,
     executionScope: SourceRange,
   ) => {
+    consumeWork?.(1);
     const binding = {
       declarationStart,
       executionScope,
@@ -342,6 +351,7 @@ export function collectStaticStringBindingsFromAst(
     declarationStart: number,
     executionScope: SourceRange,
   ) => {
+    consumeWork?.(availableBindings.length * (writes.length + 1) * (identifierBindings.length + 1));
     const exactBinding = availableBindings.find(
       (binding) =>
         binding.name === sourceName &&
@@ -360,6 +370,7 @@ export function collectStaticStringBindingsFromAst(
         isStaticStringBindingActiveAtIndex(binding, declarationStart, writes, identifierBindings),
     );
     for (const sourceBinding of sourceBindings) {
+      consumeWork?.(availableBindings.length + 1);
       const name = `${targetName}${sourceBinding.name.slice(sourceName.length)}`;
       if (availableBindings.some((binding) => binding.name === name && binding.start >= declarationStart)) {
         continue;
@@ -381,6 +392,7 @@ export function collectStaticStringBindingsFromAst(
     }
     const seenMembers = new Set<string>();
     for (let index = (unwrapped.properties || []).length - 1; index >= 0; index -= 1) {
+      consumeWork?.((availableBindings.length + 1) * (identifierBindings.length + 1));
       const property = unwrapped.properties[index];
       if (!property) {
         continue;
@@ -410,6 +422,8 @@ export function collectStaticStringBindingsFromAst(
   };
   walkAstAncestor(ast, {
     VariableDeclarator(node: any, ancestors: any[]) {
+      if (bindingNames && node.id?.type === 'Identifier' && !bindingNames.has(node.id.name)) return;
+      consumeWork?.((availableBindings.length + aliasCopies.length + 1) * (identifierBindings.length + 1));
       const declaration = findAstAncestor(ancestors, 'VariableDeclaration');
       if (declaration?.kind !== 'const') {
         return;
@@ -423,6 +437,7 @@ export function collectStaticStringBindingsFromAst(
           return;
         }
         collectAstObjectPatternPathAliases(node.id, (name, members, aliasNode) => {
+          if (bindingNames && !bindingNames.has(name)) return;
           const aliasDeclarationStart = typeof aliasNode?.start === 'number' ? aliasNode.start : declarationStart;
           copyMemberBindings(
             `${sourceName}.${members.join('.')}`,
@@ -449,6 +464,7 @@ export function collectStaticStringBindingsFromAst(
       }
     },
   });
+  consumeWork?.(bindings.length * (writes.length + 1) * (identifierBindings.length + 1));
   return trimStaticStringBindingsAfterWrites(bindings, writes, identifierBindings);
 }
 
@@ -512,14 +528,18 @@ export function collectStaticFilterValueBindingsFromAst(
   ast: any,
   source: string,
   identifierBindings: AstIdentifierBinding[],
+  consumeWork?: (work: number) => void,
+  bindingNames?: ReadonlySet<string>,
 ): StaticFilterValueBinding[] {
   const bindings: StaticFilterValueBinding[] = [];
   const availableBindings: StaticFilterValueBinding[] = [];
-  const writes = collectAstStaticBindingWritesFromAst(ast, source, identifierBindings);
-  const getActiveBindings = (index: number) =>
-    trimStaticFilterValueBindingsAfterWrites(availableBindings, writes, identifierBindings).filter(
+  const writes = collectAstStaticBindingWritesFromAst(ast, source, identifierBindings, consumeWork, bindingNames);
+  const getActiveBindings = (index: number) => {
+    consumeWork?.(availableBindings.length * (writes.length + 1) * (identifierBindings.length + 1));
+    return trimStaticFilterValueBindingsAfterWrites(availableBindings, writes, identifierBindings).filter(
       (binding) => index >= binding.start && index < binding.end,
     );
+  };
   const addBinding = (
     name: string,
     valueNode: any,
@@ -541,6 +561,8 @@ export function collectStaticFilterValueBindingsFromAst(
   };
   walkAstAncestor(ast, {
     VariableDeclarator(node: any, ancestors: any[]) {
+      if (bindingNames && node.id?.type === 'Identifier' && !bindingNames.has(node.id.name)) return;
+      consumeWork?.(1);
       if (!node.init) {
         return;
       }
@@ -561,6 +583,7 @@ export function collectStaticFilterValueBindingsFromAst(
           return;
         }
         collectAstObjectPatternPathAliases(node.id, (name, members, aliasNode) => {
+          if (bindingNames && !bindingNames.has(name)) return;
           const property = getRunJsObjectPropertyByPath(
             sourceObject,
             members,
@@ -586,6 +609,7 @@ export function collectStaticFilterValueBindingsFromAst(
       addBinding(node.id.name, node.init, node, scope, declarationStart, executionScope);
     },
   });
+  consumeWork?.(bindings.length * (writes.length + 1) * (identifierBindings.length + 1));
   return trimStaticFilterValueBindingsAfterWrites(bindings, writes, identifierBindings);
 }
 
@@ -615,22 +639,36 @@ export function collectAstStaticBindingWritesFromAst(
   ast: any,
   source: string,
   identifierBindings: AstIdentifierBinding[],
+  consumeWork?: (work: number) => void,
+  bindingNames?: ReadonlySet<string>,
 ): AstIdentifierWrite[] {
-  const writes = collectAstIdentifierWritesFromAst(ast, source);
-  const aliasCopies = collectAstStaticObjectAliasCopiesFromAst(ast, source, identifierBindings);
-  return [...writes, ...collectAstStaticAliasCopyWrites(writes, aliasCopies, identifierBindings)];
+  const writes = collectAstIdentifierWritesFromAst(ast, source).filter(
+    (write) => !bindingNames || bindingNames.has(getAstAliasRootName(write.name)),
+  );
+  const aliasCopies = collectAstStaticObjectAliasCopiesFromAst(
+    ast,
+    source,
+    identifierBindings,
+    consumeWork,
+    bindingNames,
+  );
+  return [...writes, ...collectAstStaticAliasCopyWrites(writes, aliasCopies, identifierBindings, consumeWork)];
 }
 
 export function collectAstStaticObjectAliasCopiesFromAst(
   ast: any,
   source: string,
   identifierBindings: AstIdentifierBinding[],
+  consumeWork?: (work: number) => void,
+  bindingNames?: ReadonlySet<string>,
 ): AstStaticObjectAliasCopy[] {
   const aliases: AstStaticObjectAliasCopy[] = [];
   const resolveSourceName = (node: any) => resolveAstStaticAliasCopySourceName(node, aliases, identifierBindings);
 
   walkAstAncestor(ast, {
     VariableDeclarator(node: any, ancestors: any[]) {
+      if (bindingNames && node.id?.type === 'Identifier' && !bindingNames.has(node.id.name)) return;
+      consumeWork?.((aliases.length + 1) * (identifierBindings.length + 1));
       if (!node.init) {
         return;
       }
@@ -641,6 +679,7 @@ export function collectAstStaticObjectAliasCopiesFromAst(
       const scope = getAstBindingScopeRange(ancestors, source.length);
       const executionScope = getAstExecutionScopeRange(ancestors, source.length);
       const addAlias = (name: string, sourceName: string | undefined, aliasNode: any) => {
+        if (bindingNames && !bindingNames.has(name)) return;
         if (!sourceName || sourceName === name || sourceName.startsWith(`${name}.`)) {
           return;
         }
@@ -710,6 +749,7 @@ export function collectAstStaticAliasCopyWrites(
   writes: AstIdentifierWrite[],
   aliases: AstStaticObjectAliasCopy[],
   identifierBindings: AstIdentifierBinding[],
+  consumeWork?: (work: number) => void,
 ): AstIdentifierWrite[] {
   const mirroredWrites: AstIdentifierWrite[] = [];
   const seen = new Set(writes.map((write) => getAstIdentifierWriteKey(write)));
@@ -731,6 +771,7 @@ export function collectAstStaticAliasCopyWrites(
   for (let index = 0; index < queue.length; index += 1) {
     const write = queue[index];
     for (const alias of aliases) {
+      consumeWork?.(2 * (identifierBindings.length + 1));
       if (!isAstStaticObjectAliasCopyActiveAtIndex(alias, write.index, identifierBindings)) {
         continue;
       }

--- a/packages/plugins/@nocobase/plugin-flow-engine/src/server/flow-surfaces/runjs-authoring/ast/static-values.ts
+++ b/packages/plugins/@nocobase/plugin-flow-engine/src/server/flow-surfaces/runjs-authoring/ast/static-values.ts
@@ -25,7 +25,7 @@ import type {
   StaticStringBinding,
 } from '../internal-types';
 import { AST_DYNAMIC_MEMBER_ALIAS } from '../internal-types';
-import { AST_CTX_METHOD_NAMES } from '../runtime/constants';
+import { AST_CTX_METHOD_NAMES, MAX_RUNJS_SOURCE_LENGTH } from '../runtime/constants';
 import { normalizeText } from '../runtime/surface';
 import {
   findAstAncestor,
@@ -277,7 +277,7 @@ export function resolveAstStaticStringValue(node: any, source: string): string |
 }
 
 export function resolveAstStaticTemplateLiteralValue(
-  node: any,
+  node: unknown,
   source: string,
   stringBindings: StaticStringBinding[],
   identifierBindings: AstIdentifierBinding[],
@@ -291,12 +291,15 @@ export function resolveAstStaticTemplateLiteralValue(
   let value = '';
   for (let index = 0; index < quasis.length; index += 1) {
     const quasi = quasis[index];
-    value += quasi?.value?.cooked ?? quasi?.value?.raw ?? '';
+    const text = quasi?.value?.cooked ?? quasi?.value?.raw ?? '';
+    // Bound expanded strings too; short chains of constants can otherwise grow exponentially.
+    if (value.length + text.length > MAX_RUNJS_SOURCE_LENGTH) return undefined;
+    value += text;
     if (index >= expressions.length) {
       continue;
     }
     const expression = resolveAstResourceTypeExpression(expressions[index], source, stringBindings, identifierBindings);
-    if (expression.status !== 'resolved') {
+    if (expression.status !== 'resolved' || value.length + expression.value.length > MAX_RUNJS_SOURCE_LENGTH) {
       return undefined;
     }
     value += expression.value;

--- a/packages/plugins/@nocobase/plugin-flow-engine/src/server/variables/allow-list.ts
+++ b/packages/plugins/@nocobase/plugin-flow-engine/src/server/variables/allow-list.ts
@@ -352,10 +352,21 @@ async function createFlowModelVariableContractFromNode(
   runtimeNode: FlowModelNodeSnapshot,
   source: FlowModelContractSource,
 ) {
-  const variableSource =
+  let variableSource: unknown =
     source === 'formAssignRules'
       ? (await resolveFormAssignRulesVariableSource(ctx, contractNode)) ?? {}
       : contractNode.options;
+  // Form linkage rules are stored on the grid but run with the form model's resolve descriptor.
+  if (source === 'node' && isFormAssignRulesOwnerNode(contractNode)) {
+    const grid = await getFlowModelChildNode(ctx, contractNode.uid, 'grid');
+    if (grid && isFormAssignRulesContractPair(contractNode, grid) && !isReferenceFormGridNode(grid)) {
+      const stepParams = isObject(grid.options.stepParams) ? grid.options.stepParams : null;
+      const eventSettings = stepParams && isObject(stepParams.eventSettings) ? stepParams.eventSettings : null;
+      if (typeof eventSettings?.linkageRules !== 'undefined') {
+        variableSource = [variableSource, eventSettings.linkageRules];
+      }
+    }
+  }
   const prepared = prepareFlowModelVariableSource(
     variableSource,
     source === 'formAssignRules' ? { isRunJsValuePath: isFormAssignRulesRunJsValuePath } : undefined,

--- a/packages/plugins/@nocobase/plugin-flow-engine/src/server/variables/allow-list.ts
+++ b/packages/plugins/@nocobase/plugin-flow-engine/src/server/variables/allow-list.ts
@@ -305,6 +305,28 @@ async function resolveFormAssignRulesVariableSource(ctx: ResourcerContext, contr
     : undefined;
 }
 
+function readFormLinkageRulesSource(node: FlowModelNodeSnapshot) {
+  const steps = isObject(node.options.stepParams) ? node.options.stepParams : null;
+  const events = steps && isObject(steps.eventSettings) ? steps.eventSettings : null;
+  // Keep the persisted path so RunJS values in linkage rules are recognized too.
+  return { stepParams: { eventSettings: { linkageRules: events?.linkageRules } } };
+}
+
+async function collectFormLinkageRuleSources(ctx: ResourcerContext, form: FlowModelNodeSnapshot) {
+  const grid = await getFlowModelChildNode(ctx, form.uid, 'grid');
+  if (!grid || !isFormAssignRulesContractPair(form, grid)) return [];
+  if (!isReferenceFormGridNode(grid)) return [readFormLinkageRulesSource(grid)];
+
+  const targetUid = getReferenceFormGridTargetUid(grid);
+  const target = targetUid ? await getFlowModelNode(ctx, targetUid) : null;
+  if (!target || !isFormAssignRulesOwnerNode(target)) return [];
+  const targetGrid = await getFlowModelChildNode(ctx, target.uid, 'grid');
+  if (!targetGrid || !isFormAssignRulesContractPair(target, targetGrid) || isReferenceFormGridNode(targetGrid)) {
+    return [];
+  }
+  return [readFormLinkageRulesSource(target), readFormLinkageRulesSource(targetGrid)];
+}
+
 function createRecordSlotCompilerOptions(ctx: ResourcerContext, currentNode?: FlowModelNodeSnapshot) {
   let ancestors: Promise<readonly FlowModelNodeSnapshot[]> | undefined;
   return {
@@ -354,18 +376,11 @@ async function createFlowModelVariableContractFromNode(
 ) {
   let variableSource: unknown =
     source === 'formAssignRules'
-      ? (await resolveFormAssignRulesVariableSource(ctx, contractNode)) ?? {}
+      ? ((await resolveFormAssignRulesVariableSource(ctx, contractNode)) ?? {})
       : contractNode.options;
   // Form linkage rules are stored on the grid but run with the form model's resolve descriptor.
   if (source === 'node' && isFormAssignRulesOwnerNode(contractNode)) {
-    const grid = await getFlowModelChildNode(ctx, contractNode.uid, 'grid');
-    if (grid && isFormAssignRulesContractPair(contractNode, grid) && !isReferenceFormGridNode(grid)) {
-      const stepParams = isObject(grid.options.stepParams) ? grid.options.stepParams : null;
-      const eventSettings = stepParams && isObject(stepParams.eventSettings) ? stepParams.eventSettings : null;
-      if (typeof eventSettings?.linkageRules !== 'undefined') {
-        variableSource = [variableSource, eventSettings.linkageRules];
-      }
-    }
+    variableSource = [variableSource, ...(await collectFormLinkageRuleSources(ctx, contractNode))];
   }
   const prepared = prepareFlowModelVariableSource(
     variableSource,
@@ -516,6 +531,31 @@ async function resolveFormAssignRulesContractNode(
   return ancestorUids?.has(contractNode.uid) === true ? contractNode : null;
 }
 
+async function resolveReferenceBlockContractNode(
+  ctx: ResourcerContext,
+  runtimeNode: FlowModelNodeSnapshot,
+  contractModelUid: string,
+) {
+  const reference = await getFlowModelNode(ctx, contractModelUid);
+  if (reference?.options.use !== 'ReferenceBlockModel') return null;
+  let current = reference;
+  const seen = new Set([reference.uid]);
+  // Match ReferenceBlockModel's bounded reference-of-reference resolution.
+  for (let depth = 0; depth < 20; depth++) {
+    const steps = isObject(current.options.stepParams) ? current.options.stepParams : null;
+    const settings = steps && isObject(steps.referenceSettings) ? steps.referenceSettings : null;
+    const target = settings && isObject(settings.target) ? settings.target : null;
+    const targetUid = typeof target?.targetUid === 'string' ? target.targetUid.trim() : '';
+    if (!targetUid || seen.has(targetUid)) return null;
+    seen.add(targetUid);
+    const node = await getFlowModelNode(ctx, targetUid);
+    if (!node) return null;
+    if (node.options.use !== 'ReferenceBlockModel') return node.uid === runtimeNode.uid ? reference : null;
+    current = node;
+  }
+  return null;
+}
+
 function createPolicy(
   allowAll = false,
   allowedPaths: ReadonlySet<string> = new Set(),
@@ -646,11 +686,16 @@ export async function authorizeVariablesResolve(
   let contractNode = currentNode;
   let contractSource: FlowModelContractSource = 'node';
   if (hasContractRd) {
-    contractNode =
+    const reference =
       currentNode && contractModelUid
-        ? await resolveFormAssignRulesContractNode(ctx, currentNode, contractModelUid)
+        ? await resolveReferenceBlockContractNode(ctx, currentNode, contractModelUid)
         : null;
-    contractSource = 'formAssignRules';
+    contractNode =
+      reference ||
+      (currentNode && contractModelUid
+        ? await resolveFormAssignRulesContractNode(ctx, currentNode, contractModelUid)
+        : null);
+    contractSource = reference ? 'node' : 'formAssignRules';
     if (!contractNode) {
       return denied(analysis, bindingPlan.contextParams, policy, recordSlotPolicies, flowModelUid || undefined);
     }

--- a/packages/plugins/@nocobase/plugin-flow-engine/src/server/variables/allow-list.ts
+++ b/packages/plugins/@nocobase/plugin-flow-engine/src/server/variables/allow-list.ts
@@ -374,35 +374,25 @@ async function createFlowModelVariableContractFromNode(
   runtimeNode: FlowModelNodeSnapshot,
   source: FlowModelContractSource,
 ) {
-  let variableSource: unknown =
-    source === 'formAssignRules'
-      ? (await resolveFormAssignRulesVariableSource(ctx, contractNode)) ?? {}
-      : contractNode.options;
-  if (source === 'node') {
-    // Forwarded reference events use both instance parameters and the target model's existing configuration.
+  const sources: unknown[] = [];
+  if (source === 'formAssignRules') {
+    sources.push((await resolveFormAssignRulesVariableSource(ctx, contractNode)) ?? {});
+  } else {
+    // At most two owners and four linkage sources, each with its own bounded scan.
     const nodes = contractNode.uid === runtimeNode.uid ? [contractNode] : [contractNode, runtimeNode];
-    const sources: unknown[] = [];
     for (const node of nodes) {
       sources.push(node.options);
       if (isFormAssignRulesOwnerNode(node)) {
         sources.push(...(await collectFormLinkageRuleSources(ctx, node)));
       }
     }
-    variableSource = sources.length === 1 ? sources[0] : sources;
   }
-  const prepared = prepareFlowModelVariableSource(
-    variableSource,
-    source === 'formAssignRules' ? { isRunJsValuePath: isFormAssignRulesRunJsValuePath } : undefined,
-  );
-  // At most two bounded fallback scans preserve both owners without including oversized supplemental sources.
-  const sources =
-    !prepared.ok && source === 'node' && variableSource !== contractNode.options
-      ? (contractNode.uid === runtimeNode.uid ? [contractNode] : [contractNode, runtimeNode]).map((node) =>
-          prepareFlowModelVariableSource(node.options),
-        )
-      : [prepared];
   const paths: AnalyzedTemplate['paths'][number][] = [];
-  for (const item of sources) {
+  for (const variableSource of sources) {
+    const item = prepareFlowModelVariableSource(
+      variableSource,
+      source === 'formAssignRules' ? { isRunJsValuePath: isFormAssignRulesRunJsValuePath } : undefined,
+    );
     if (!item.ok) continue;
     const contractSource = item.runJsTemplates.length
       ? [item.templateSource, ...item.runJsTemplates]

--- a/packages/plugins/@nocobase/plugin-flow-engine/src/server/variables/allow-list.ts
+++ b/packages/plugins/@nocobase/plugin-flow-engine/src/server/variables/allow-list.ts
@@ -376,7 +376,7 @@ async function createFlowModelVariableContractFromNode(
 ) {
   let variableSource: unknown =
     source === 'formAssignRules'
-      ? ((await resolveFormAssignRulesVariableSource(ctx, contractNode)) ?? {})
+      ? (await resolveFormAssignRulesVariableSource(ctx, contractNode)) ?? {}
       : contractNode.options;
   if (source === 'node') {
     // Forwarded reference events use both instance parameters and the target model's existing configuration.
@@ -390,10 +390,14 @@ async function createFlowModelVariableContractFromNode(
     }
     variableSource = sources.length === 1 ? sources[0] : sources;
   }
-  const prepared = prepareFlowModelVariableSource(
+  let prepared = prepareFlowModelVariableSource(
     variableSource,
     source === 'formAssignRules' ? { isRunJsValuePath: isFormAssignRulesRunJsValuePath } : undefined,
   );
+  // Oversized supplemental configuration must not discard the original node's dependencies.
+  if (!prepared.ok && source === 'node' && variableSource !== contractNode.options) {
+    prepared = prepareFlowModelVariableSource(contractNode.options);
+  }
   const contractSource = prepared.ok
     ? prepared.runJsTemplates.length
       ? [prepared.templateSource, ...prepared.runJsTemplates]

--- a/packages/plugins/@nocobase/plugin-flow-engine/src/server/variables/allow-list.ts
+++ b/packages/plugins/@nocobase/plugin-flow-engine/src/server/variables/allow-list.ts
@@ -378,9 +378,17 @@ async function createFlowModelVariableContractFromNode(
     source === 'formAssignRules'
       ? ((await resolveFormAssignRulesVariableSource(ctx, contractNode)) ?? {})
       : contractNode.options;
-  // Form linkage rules are stored on the grid but run with the form model's resolve descriptor.
-  if (source === 'node' && isFormAssignRulesOwnerNode(contractNode)) {
-    variableSource = [variableSource, ...(await collectFormLinkageRuleSources(ctx, contractNode))];
+  if (source === 'node') {
+    // Forwarded reference events use both instance parameters and the target model's existing configuration.
+    const nodes = contractNode.uid === runtimeNode.uid ? [contractNode] : [contractNode, runtimeNode];
+    const sources: unknown[] = [];
+    for (const node of nodes) {
+      sources.push(node.options);
+      if (isFormAssignRulesOwnerNode(node)) {
+        sources.push(...(await collectFormLinkageRuleSources(ctx, node)));
+      }
+    }
+    variableSource = sources.length === 1 ? sources[0] : sources;
   }
   const prepared = prepareFlowModelVariableSource(
     variableSource,

--- a/packages/plugins/@nocobase/plugin-flow-engine/src/server/variables/allow-list.ts
+++ b/packages/plugins/@nocobase/plugin-flow-engine/src/server/variables/allow-list.ts
@@ -390,21 +390,28 @@ async function createFlowModelVariableContractFromNode(
     }
     variableSource = sources.length === 1 ? sources[0] : sources;
   }
-  let prepared = prepareFlowModelVariableSource(
+  const prepared = prepareFlowModelVariableSource(
     variableSource,
     source === 'formAssignRules' ? { isRunJsValuePath: isFormAssignRulesRunJsValuePath } : undefined,
   );
-  // Oversized supplemental configuration must not discard the original node's dependencies.
-  if (!prepared.ok && source === 'node' && variableSource !== contractNode.options) {
-    prepared = prepareFlowModelVariableSource(contractNode.options);
+  // At most two bounded fallback scans preserve both owners without including oversized supplemental sources.
+  const sources =
+    !prepared.ok && source === 'node' && variableSource !== contractNode.options
+      ? (contractNode.uid === runtimeNode.uid ? [contractNode] : [contractNode, runtimeNode]).map((node) =>
+          prepareFlowModelVariableSource(node.options),
+        )
+      : [prepared];
+  const paths: AnalyzedTemplate['paths'][number][] = [];
+  for (const item of sources) {
+    if (!item.ok) continue;
+    const contractSource = item.runJsTemplates.length
+      ? [item.templateSource, ...item.runJsTemplates]
+      : item.templateSource;
+    const result = analyzeVariableTemplateSafely(contractSource, { mode: 'flow-model' });
+    if (result.ok) paths.push(...result.analysis.paths);
   }
-  const contractSource = prepared.ok
-    ? prepared.runJsTemplates.length
-      ? [prepared.templateSource, ...prepared.runJsTemplates]
-      : prepared.templateSource
-    : {};
-  const result = analyzeVariableTemplateSafely(contractSource, { mode: 'flow-model' });
-  const analysis = result.ok ? result.analysis : analyzeVariableTemplate({}, { mode: 'flow-model' });
+  // Compile all occurrences together so conflicting record-slot policies remain rejected.
+  const analysis = { ...analyzeVariableTemplate({}, { mode: 'flow-model' }), paths };
   return await createFlowModelVariableContract(analysis, createRecordSlotCompilerOptions(ctx, runtimeNode));
 }
 

--- a/packages/plugins/@nocobase/plugin-flow-engine/src/server/variables/form-item-record-slot-resolvers.ts
+++ b/packages/plugins/@nocobase/plugin-flow-engine/src/server/variables/form-item-record-slot-resolvers.ts
@@ -7,7 +7,8 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import FlowModelRepository from '../repository';
+import type { ResourcerContext } from '@nocobase/resourcer';
+import type FlowModelRepository from '../repository';
 import type {
   RecordSlotResolverInput,
   RecordSlotResolverRegistration,
@@ -18,6 +19,8 @@ type FlowModelOptions = Readonly<{
   stepParams?: unknown;
   subModels?: unknown;
 }>;
+
+const requestModelTrees = new WeakMap<ResourcerContext, Map<string, Promise<FlowModelOptions | undefined>>>();
 
 type ResourceTarget = Readonly<{
   associationName?: string;
@@ -190,8 +193,18 @@ async function loadModelTree(input: RecordSlotResolverInput, node: unknown) {
   if (options && getFormItems(options)) return options;
   const uid = isObject(node) && typeof node.uid === 'string' ? node.uid : undefined;
   if (!uid || !input.ctx) return undefined;
+  let cache = requestModelTrees.get(input.ctx);
+  if (!cache) {
+    cache = new Map();
+    requestModelTrees.set(input.ctx, cache);
+  }
+  const cached = cache.get(uid);
+  if (cached) return cached;
   const repository = input.ctx.db.getCollection('flowModels').repository as FlowModelRepository;
-  return getModelOptions(await repository.findModelById(uid, { includeAsyncNode: true }));
+  // Share pending loads across expressions and contracts, while keeping record-slot resolution per occurrence.
+  const load = repository.findModelById(uid, { includeAsyncNode: true }).then(getModelOptions);
+  cache.set(uid, load);
+  return load;
 }
 
 async function findFormProvider(input: RecordSlotResolverInput, lineage: readonly unknown[]) {

--- a/packages/plugins/@nocobase/plugin-flow-engine/src/server/variables/runjs-variable-dependencies.ts
+++ b/packages/plugins/@nocobase/plugin-flow-engine/src/server/variables/runjs-variable-dependencies.ts
@@ -67,6 +67,8 @@ type TraversalFrame = Readonly<{
   key: string;
   parent: TraversalContainer;
   pathTail: readonly string[];
+  flowRegistry?: unknown;
+  runJsValue?: boolean;
 }>;
 
 type EnumerableDataEntry = readonly [key: string, value: unknown];
@@ -113,8 +115,30 @@ function readPersistedRunJsValue(entries: readonly EnumerableDataEntry[]): Persi
   return { code, version: version as string | null | undefined };
 }
 
-function isPersistedRunJsPath(pathTail: readonly string[]) {
-  return RUNJS_PATH_SUFFIXES.has(pathTail.slice(-3).join('.'));
+function readDataProperty(value: unknown, key: string): unknown {
+  return value && typeof value === 'object' ? Object.getOwnPropertyDescriptor(value, key)?.value : undefined;
+}
+
+function isPersistedRunJsPath(pathTail: readonly string[], flowRegistry?: unknown) {
+  const tail = pathTail.slice(-3);
+  if (RUNJS_PATH_SUFFIXES.has(tail.join('.'))) return true;
+  if (tail[0] === 'stepParams') {
+    const steps = readDataProperty(readDataProperty(flowRegistry, tail[1]), 'steps');
+    if (readDataProperty(readDataProperty(steps, tail[2]), 'use') === 'runjs') return true;
+  }
+  const path = pathTail.join('.');
+  return (
+    /(?:^|\.)linkageRules\.value\.\d+\.actions\.\d+\.params\.value\.\d+\.value$/.test(path) ||
+    /(?:^|\.)formFilterBlockModelSettings\.defaultValues\.value\.\d+\.value$/.test(path)
+  );
+}
+
+function isPersistedRunJsStringPath(pathTail: readonly string[]) {
+  const path = pathTail.join('.');
+  return (
+    /(?:^|\.)linkageRules\.value\.\d+\.actions\.\d+\.params\.value\.script$/.test(path) ||
+    /(?:^|\.)chartSettings\.configure\.chart\.(?:option|events)\.raw$/.test(path)
+  );
 }
 
 function createTraversalContainer(input: object, descriptors: PropertyDescriptorMap): TraversalContainer {
@@ -434,6 +458,20 @@ export function prepareFlowModelVariableSource(
     let totalStringLength = 0;
     let totalSourceLength = 0;
 
+    const prepareRunJsCode = (code: string, version?: string | null) => {
+      sourceCount += 1;
+      totalSourceLength += code.length;
+      if (
+        sourceCount > MAX_RUNJS_SOURCES_PER_REQUEST ||
+        code.length > MAX_RUNJS_SOURCE_LENGTH ||
+        totalSourceLength > MAX_RUNJS_TOTAL_SOURCE_LENGTH
+      ) {
+        throw new RangeError('RunJS variable source exceeds its limit');
+      }
+      extractStaticVariableTemplates(code).forEach((template) => templates.add(template));
+      return version === 'v2' ? '' : maskJavaScriptComments(code);
+    };
+
     while (stack.length) {
       const frame = stack.pop();
       if (!frame) break;
@@ -448,7 +486,11 @@ export function prepareFlowModelVariableSource(
             return { ok: false };
           }
         }
-        defineTraversalValue(parent, key, input);
+        const prepared =
+          typeof input === 'string' && !options.isRunJsValuePath && isPersistedRunJsStringPath(pathTail)
+            ? prepareRunJsCode(input)
+            : input;
+        defineTraversalValue(parent, key, prepared);
         continue;
       }
       if (seen.has(input)) return { ok: false };
@@ -464,33 +506,28 @@ export function prepareFlowModelVariableSource(
           return { ok: false };
         }
       }
-      const runJsPath = options.isRunJsValuePath ? options.isRunJsValuePath(pathTail) : isPersistedRunJsPath(pathTail);
+      const runJsPath = options.isRunJsValuePath
+        ? options.isRunJsValuePath(pathTail)
+        : frame.runJsValue || isPersistedRunJsPath(pathTail, frame.flowRegistry);
       const runJs = !Array.isArray(input) && runJsPath ? readPersistedRunJsValue(entries) : undefined;
       const output = createTraversalContainer(input, descriptors);
       defineTraversalValue(parent, key, output);
 
       if (runJs) {
         scheduledNodes += entries.length;
-        sourceCount += 1;
         totalStringLength += runJs.code.length + (runJs.version?.length || 0);
-        totalSourceLength += runJs.code.length;
         if (
           scheduledNodes > MAX_FLOW_MODEL_VARIABLE_SOURCE_NODES ||
           runJs.code.length > MAX_FLOW_MODEL_VARIABLE_STRING_LENGTH ||
           (runJs.version != null && runJs.version.length > MAX_FLOW_MODEL_VARIABLE_STRING_LENGTH) ||
-          totalStringLength > MAX_FLOW_MODEL_VARIABLE_TOTAL_STRING_LENGTH ||
-          sourceCount > MAX_RUNJS_SOURCES_PER_REQUEST ||
-          runJs.code.length > MAX_RUNJS_SOURCE_LENGTH ||
-          totalSourceLength > MAX_RUNJS_TOTAL_SOURCE_LENGTH
+          totalStringLength > MAX_FLOW_MODEL_VARIABLE_TOTAL_STRING_LENGTH
         ) {
           return { ok: false };
         }
+        const code = prepareRunJsCode(runJs.code, runJs.version);
         for (const [entryKey, entryValue] of entries) {
-          const preparedEntryValue =
-            entryKey === 'code' ? (runJs.version === 'v2' ? '' : maskJavaScriptComments(runJs.code)) : entryValue;
-          defineTraversalValue(output, entryKey, preparedEntryValue);
+          defineTraversalValue(output, entryKey, entryKey === 'code' ? code : entryValue);
         }
-        extractStaticVariableTemplates(runJs.code).forEach((template) => templates.add(template));
         continue;
       }
 
@@ -505,7 +542,9 @@ export function prepareFlowModelVariableSource(
           input: entryValue,
           key: entryKey,
           parent: output,
-          pathTail: options.isRunJsValuePath ? nextPath : nextPath.slice(-3),
+          pathTail: options.isRunJsValuePath ? nextPath : nextPath.slice(-12),
+          flowRegistry: entryKey === 'stepParams' ? descriptors.flowRegistry?.value : frame.flowRegistry,
+          runJsValue: entryKey === 'defaultParams' && descriptors.use?.value === 'runjs',
         });
       }
     }

--- a/packages/plugins/@nocobase/plugin-flow-engine/src/server/variables/runjs-variable-dependencies.ts
+++ b/packages/plugins/@nocobase/plugin-flow-engine/src/server/variables/runjs-variable-dependencies.ts
@@ -9,7 +9,10 @@
 
 import { isAstFunctionLike, unwrapAstChainExpression } from '../flow-surfaces/runjs-authoring/ast/bindings';
 import { maskJavaScriptComments } from '../flow-surfaces/runjs-authoring/ast/source';
-import { collectAstIdentifierBindingsFromAst } from '../flow-surfaces/runjs-authoring/ast/static-bindings';
+import {
+  collectAstIdentifierBindingsFromAst,
+  collectStaticStringBindingsFromAst,
+} from '../flow-surfaces/runjs-authoring/ast/static-bindings';
 import {
   collectAstPatternBindingIdentifiers,
   getAstMemberRootIdentifier,
@@ -17,6 +20,7 @@ import {
   hasAstActiveBinding,
   isUnshadowedCtxIdentifier,
   resolveAstStaticStringValue,
+  resolveRunJsStaticString,
 } from '../flow-surfaces/runjs-authoring/ast/static-values';
 import { parseRunJsAuthoringAst } from '../flow-surfaces/runjs-authoring/ast/parser';
 import { walkAstAncestor, walkAstSimple } from '../flow-surfaces/runjs-authoring/ast/walk';
@@ -424,6 +428,7 @@ function extractStaticVariableTemplates(code: string): string[] {
     return [];
   }
 
+  const stringBindings = collectStaticStringBindingsFromAst(parsed.ast, code, [], identifierBindings);
   const functionCtxParameterCache = new WeakMap<object, boolean>();
   const templates = new Set<string>();
   walkAstAncestor(parsed.ast, {
@@ -435,8 +440,19 @@ function extractStaticVariableTemplates(code: string): string[] {
         if (template) templates.add(template);
         return;
       }
-      if (methodName !== 'resolveJsonTemplate' || node.arguments?.length !== 1) return;
-      const resolved = resolveStaticJsonValue(node.arguments[0], code);
+      if (methodName !== 'resolveJsonTemplate' || !node.arguments?.length || node.arguments.length > 2) return;
+      if (node.arguments.length === 2) {
+        const options = unwrapAstChainExpression(node.arguments[1]) as AstNode | undefined;
+        // An empty options object keeps the current contract owner.
+        if (options?.type !== 'ObjectExpression' || options.properties?.length !== 0) return;
+      }
+      const argument = unwrapAstChainExpression(node.arguments[0]) as AstNode | undefined;
+      const staticString =
+        argument?.type === 'Identifier'
+          ? resolveRunJsStaticString(argument, code, stringBindings, identifierBindings)
+          : undefined;
+      const resolved: StaticJsonResult =
+        typeof staticString === 'string' ? { ok: true, value: staticString } : resolveStaticJsonValue(argument, code);
       if (!resolved.ok) return;
       collectValidatedResolveJsonTemplates(resolved.value).forEach((template) => templates.add(template));
     },

--- a/packages/plugins/@nocobase/plugin-flow-engine/src/server/variables/runjs-variable-dependencies.ts
+++ b/packages/plugins/@nocobase/plugin-flow-engine/src/server/variables/runjs-variable-dependencies.ts
@@ -459,16 +459,16 @@ export function prepareFlowModelVariableSource(
     let totalSourceLength = 0;
 
     const prepareRunJsCode = (code: string, version?: string | null) => {
-      sourceCount += 1;
-      totalSourceLength += code.length;
+      // AST limits only skip dependency extraction; configured templates still use the model's string budget.
       if (
-        sourceCount > MAX_RUNJS_SOURCES_PER_REQUEST ||
-        code.length > MAX_RUNJS_SOURCE_LENGTH ||
-        totalSourceLength > MAX_RUNJS_TOTAL_SOURCE_LENGTH
+        sourceCount < MAX_RUNJS_SOURCES_PER_REQUEST &&
+        code.length <= MAX_RUNJS_SOURCE_LENGTH &&
+        totalSourceLength + code.length <= MAX_RUNJS_TOTAL_SOURCE_LENGTH
       ) {
-        throw new RangeError('RunJS variable source exceeds its limit');
+        sourceCount += 1;
+        totalSourceLength += code.length;
+        extractStaticVariableTemplates(code).forEach((template) => templates.add(template));
       }
-      extractStaticVariableTemplates(code).forEach((template) => templates.add(template));
       return version === 'v2' ? '' : maskJavaScriptComments(code);
     };
 

--- a/packages/plugins/@nocobase/plugin-flow-engine/src/server/variables/runjs-variable-dependencies.ts
+++ b/packages/plugins/@nocobase/plugin-flow-engine/src/server/variables/runjs-variable-dependencies.ts
@@ -46,6 +46,8 @@ type AstNode = Readonly<{
   computed?: boolean;
   elements?: readonly unknown[];
   expressions?: readonly unknown[];
+  id?: unknown;
+  init?: unknown;
   kind?: string;
   key?: unknown;
   left?: unknown;
@@ -98,6 +100,8 @@ export const MAX_FLOW_MODEL_VARIABLE_SOURCE_DEPTH = 128;
 export const MAX_FLOW_MODEL_VARIABLE_SOURCE_NODES = 10_000;
 export const MAX_FLOW_MODEL_VARIABLE_STRING_LENGTH = 256 * 1024;
 export const MAX_FLOW_MODEL_VARIABLE_TOTAL_STRING_LENGTH = 1024 * 1024;
+const MAX_RUNJS_STATIC_BINDING_WORK = 100_000;
+const STATIC_BINDING_BUDGET_EXHAUSTED = Symbol('static binding budget exhausted');
 
 function getEnumerableDataEntries(value: object) {
   const descriptors = Object.getOwnPropertyDescriptors(value);
@@ -422,7 +426,41 @@ function collectValidatedResolveJsonTemplates(value: StaticJsonValue): string[] 
   return Array.from(templates);
 }
 
-function extractStaticVariableTemplates(code: string, parsed: RunJsParseResult): string[] {
+function collectBindingDependencies(ast: unknown, consumeWork: (work: number) => void) {
+  const dependencies = new Map<string, Set<string>>();
+  walkAstSimple(ast, {
+    VariableDeclarator(node: AstNode) {
+      if (!node.init) return;
+      const names: string[] = [];
+      collectAstPatternBindingIdentifiers(node.id, (name) => names.push(name));
+      walkAstSimple(node.init, {
+        Identifier(reference: AstNode) {
+          const dependency = reference.name;
+          if (!dependency) return;
+          for (const name of names) {
+            consumeWork(1);
+            // Follow aliases both ways so mutations through another name are still considered.
+            for (const [from, to] of [
+              [name, dependency],
+              [dependency, name],
+            ]) {
+              const related = dependencies.get(from) || new Set<string>();
+              related.add(to);
+              dependencies.set(from, related);
+            }
+          }
+        },
+      });
+    },
+  });
+  return dependencies;
+}
+
+function extractStaticVariableTemplates(
+  code: string,
+  parsed: RunJsParseResult,
+  consumeBindingWork: (work: number) => void,
+): string[] {
   if (!parsed.ast) return [];
 
   const identifierBindings = collectAstIdentifierBindingsFromAst(parsed.ast, code);
@@ -430,8 +468,16 @@ function extractStaticVariableTemplates(code: string, parsed: RunJsParseResult):
     return [];
   }
 
-  const stringBindings = collectStaticStringBindingsFromAst(parsed.ast, code, [], identifierBindings);
-  const valueBindings = collectStaticFilterValueBindingsFromAst(parsed.ast, code, identifierBindings);
+  let bindingDependencies: ReturnType<typeof collectBindingDependencies> | undefined;
+  const bindingResults = new Map<
+    string,
+    {
+      names: ReadonlySet<string>;
+      values: ReturnType<typeof collectStaticFilterValueBindingsFromAst>;
+      strings?: ReturnType<typeof collectStaticStringBindingsFromAst>;
+    }
+  >();
+  let bindingBudgetExhausted = false;
   const functionCtxParameterCache = new WeakMap<object, boolean>();
   const templates = new Set<string>();
   walkAstAncestor(parsed.ast, {
@@ -450,20 +496,56 @@ function extractStaticVariableTemplates(code: string, parsed: RunJsParseResult):
         if (options?.type !== 'ObjectExpression' || options.properties?.length !== 0) return;
       }
       const argument = unwrapAstChainExpression(node.arguments[0]) as AstNode | undefined;
-      const staticString =
-        argument?.type === 'Identifier'
-          ? resolveRunJsStaticString(argument, code, stringBindings, identifierBindings)
-          : undefined;
-      const resolved: StaticJsonResult =
-        typeof staticString === 'string'
-          ? { ok: true, value: staticString }
-          : resolveStaticJsonValue(
-              argument?.type === 'Identifier'
-                ? resolveAstAliasBinding(argument.name || '', argument.start || 0, valueBindings, identifierBindings)
-                    ?.valueNode
-                : argument,
+      let resolved = resolveStaticJsonValue(argument, code);
+      if (argument?.type === 'Identifier' && !bindingBudgetExhausted) {
+        try {
+          const name = argument.name || '';
+          let bindings = bindingResults.get(name);
+          if (!bindings) {
+            bindingDependencies ??= collectBindingDependencies(parsed.ast, consumeBindingWork);
+            const names = new Set([name]);
+            for (const current of names) {
+              for (const dependency of bindingDependencies.get(current) || []) {
+                consumeBindingWork(1);
+                names.add(dependency);
+              }
+            }
+            bindings = {
+              names,
+              values: collectStaticFilterValueBindingsFromAst(
+                parsed.ast,
+                code,
+                identifierBindings,
+                consumeBindingWork,
+                names,
+              ),
+            };
+            bindingResults.set(name, bindings);
+          }
+          consumeBindingWork(bindings.values.length * (identifierBindings.length + 1));
+          resolved = resolveStaticJsonValue(
+            resolveAstAliasBinding(name, argument.start || 0, bindings.values, identifierBindings)?.valueNode,
+            code,
+          );
+          if (!resolved.ok) {
+            bindings.strings ??= collectStaticStringBindingsFromAst(
+              parsed.ast,
               code,
+              [],
+              identifierBindings,
+              consumeBindingWork,
+              bindings.names,
             );
+            consumeBindingWork(bindings.strings.length * (identifierBindings.length + 1));
+            const staticString = resolveRunJsStaticString(argument, code, bindings.strings, identifierBindings);
+            if (typeof staticString === 'string') resolved = { ok: true, value: staticString };
+          }
+        } catch (error) {
+          if (error !== STATIC_BINDING_BUDGET_EXHAUSTED) throw error;
+          // Keep direct calls and legacy templates when optional binding inference reaches its budget.
+          bindingBudgetExhausted = true;
+        }
+      }
       if (!resolved.ok) return;
       collectValidatedResolveJsonTemplates(resolved.value).forEach((template) => templates.add(template));
     },
@@ -484,6 +566,11 @@ export function prepareFlowModelVariableSource(
     let sourceCount = 0;
     let totalStringLength = 0;
     let totalSourceLength = 0;
+    let remainingBindingWork = MAX_RUNJS_STATIC_BINDING_WORK;
+    const consumeBindingWork = (work: number) => {
+      remainingBindingWork -= work;
+      if (remainingBindingWork < 0) throw STATIC_BINDING_BUDGET_EXHAUSTED;
+    };
     const supplementalScripts: string[] = [];
     const parsedSources = new Map<string, RunJsParseResult>();
     const getParsedSource = (code: string) => {
@@ -504,7 +591,9 @@ export function prepareFlowModelVariableSource(
       ) {
         sourceCount += 1;
         totalSourceLength += code.length;
-        extractStaticVariableTemplates(code, getParsedSource(code)).forEach((template) => templates.add(template));
+        extractStaticVariableTemplates(code, getParsedSource(code), consumeBindingWork).forEach((template) =>
+          templates.add(template),
+        );
       }
     };
 

--- a/packages/plugins/@nocobase/plugin-flow-engine/src/server/variables/runjs-variable-dependencies.ts
+++ b/packages/plugins/@nocobase/plugin-flow-engine/src/server/variables/runjs-variable-dependencies.ts
@@ -11,6 +11,7 @@ import { isAstFunctionLike, unwrapAstChainExpression } from '../flow-surfaces/ru
 import { maskJavaScriptComments } from '../flow-surfaces/runjs-authoring/ast/source';
 import {
   collectAstIdentifierBindingsFromAst,
+  collectStaticFilterValueBindingsFromAst,
   collectStaticStringBindingsFromAst,
 } from '../flow-surfaces/runjs-authoring/ast/static-bindings';
 import {
@@ -20,6 +21,7 @@ import {
   hasAstActiveBinding,
   isUnshadowedCtxIdentifier,
   resolveAstStaticStringValue,
+  resolveAstAliasBinding,
   resolveRunJsStaticString,
 } from '../flow-surfaces/runjs-authoring/ast/static-values';
 import { parseRunJsAuthoringAst } from '../flow-surfaces/runjs-authoring/ast/parser';
@@ -429,6 +431,7 @@ function extractStaticVariableTemplates(code: string): string[] {
   }
 
   const stringBindings = collectStaticStringBindingsFromAst(parsed.ast, code, [], identifierBindings);
+  const valueBindings = collectStaticFilterValueBindingsFromAst(parsed.ast, code, identifierBindings);
   const functionCtxParameterCache = new WeakMap<object, boolean>();
   const templates = new Set<string>();
   walkAstAncestor(parsed.ast, {
@@ -452,7 +455,15 @@ function extractStaticVariableTemplates(code: string): string[] {
           ? resolveRunJsStaticString(argument, code, stringBindings, identifierBindings)
           : undefined;
       const resolved: StaticJsonResult =
-        typeof staticString === 'string' ? { ok: true, value: staticString } : resolveStaticJsonValue(argument, code);
+        typeof staticString === 'string'
+          ? { ok: true, value: staticString }
+          : resolveStaticJsonValue(
+              argument?.type === 'Identifier'
+                ? resolveAstAliasBinding(argument.name || '', argument.start || 0, valueBindings, identifierBindings)
+                    ?.valueNode
+                : argument,
+              code,
+            );
       if (!resolved.ok) return;
       collectValidatedResolveJsonTemplates(resolved.value).forEach((template) => templates.add(template));
     },
@@ -474,7 +485,7 @@ export function prepareFlowModelVariableSource(
     let totalStringLength = 0;
     let totalSourceLength = 0;
 
-    const prepareRunJsCode = (code: string, version?: string | null) => {
+    const prepareRunJsCode = (code: string, version?: string | null, preserveLegacyTemplates = false) => {
       // AST limits only skip dependency extraction; configured templates still use the model's string budget.
       if (
         sourceCount < MAX_RUNJS_SOURCES_PER_REQUEST &&
@@ -484,6 +495,9 @@ export function prepareFlowModelVariableSource(
         sourceCount += 1;
         totalSourceLength += code.length;
         extractStaticVariableTemplates(code).forEach((template) => templates.add(template));
+      } else if (preserveLegacyTemplates) {
+        // Newly recognized paths previously participated in template scanning even without AST extraction.
+        return maskJavaScriptComments(code);
       }
       return version === 'v2' ? '' : maskJavaScriptComments(code);
     };
@@ -540,7 +554,11 @@ export function prepareFlowModelVariableSource(
         ) {
           return { ok: false };
         }
-        const code = prepareRunJsCode(runJs.code, runJs.version);
+        const code = prepareRunJsCode(
+          runJs.code,
+          runJs.version,
+          !options.isRunJsValuePath && !RUNJS_PATH_SUFFIXES.has(pathTail.slice(-3).join('.')),
+        );
         for (const [entryKey, entryValue] of entries) {
           defineTraversalValue(output, entryKey, entryKey === 'code' ? code : entryValue);
         }

--- a/packages/plugins/@nocobase/plugin-flow-engine/src/server/variables/runjs-variable-dependencies.ts
+++ b/packages/plugins/@nocobase/plugin-flow-engine/src/server/variables/runjs-variable-dependencies.ts
@@ -25,6 +25,7 @@ import {
   resolveRunJsStaticString,
 } from '../flow-surfaces/runjs-authoring/ast/static-values';
 import { parseRunJsAuthoringAst } from '../flow-surfaces/runjs-authoring/ast/parser';
+import type { RunJsParseResult } from '../flow-surfaces/runjs-authoring/ast/parser';
 import { walkAstAncestor, walkAstSimple } from '../flow-surfaces/runjs-authoring/ast/walk';
 import {
   MAX_RUNJS_SOURCES_PER_REQUEST,
@@ -421,8 +422,7 @@ function collectValidatedResolveJsonTemplates(value: StaticJsonValue): string[] 
   return Array.from(templates);
 }
 
-function extractStaticVariableTemplates(code: string): string[] {
-  const parsed = parseRunJsAuthoringAst(code);
+function extractStaticVariableTemplates(code: string, parsed: RunJsParseResult): string[] {
   if (!parsed.ast) return [];
 
   const identifierBindings = collectAstIdentifierBindingsFromAst(parsed.ast, code);
@@ -485,9 +485,18 @@ export function prepareFlowModelVariableSource(
     let totalStringLength = 0;
     let totalSourceLength = 0;
     const supplementalScripts: string[] = [];
+    const parsedSources = new Map<string, RunJsParseResult>();
+    const getParsedSource = (code: string) => {
+      let parsed = parsedSources.get(code);
+      if (!parsed) {
+        parsed = parseRunJsAuthoringAst(code, { allowLegacyTemplates: true });
+        parsedSources.set(code, parsed);
+      }
+      return parsed;
+    };
 
     const extractRunJsDependencies = (code: string) => {
-      // AST limits only skip dependency extraction; configured templates still use the model's string budget.
+      // Static inference has a smaller budget than syntax parsing for legacy templates (bounded by model strings/nodes).
       if (
         sourceCount < MAX_RUNJS_SOURCES_PER_REQUEST &&
         code.length <= MAX_RUNJS_SOURCE_LENGTH &&
@@ -495,7 +504,7 @@ export function prepareFlowModelVariableSource(
       ) {
         sourceCount += 1;
         totalSourceLength += code.length;
-        extractStaticVariableTemplates(code).forEach((template) => templates.add(template));
+        extractStaticVariableTemplates(code, getParsedSource(code)).forEach((template) => templates.add(template));
       }
     };
 
@@ -503,7 +512,8 @@ export function prepareFlowModelVariableSource(
       // Existing RunJS locations get the budget first, regardless of property traversal order.
       if (preserveLegacyTemplates) supplementalScripts.push(code);
       else extractRunJsDependencies(code);
-      return version === 'v2' && !preserveLegacyTemplates ? '' : maskJavaScriptComments(code);
+      if ((version === 'v2' && !preserveLegacyTemplates) || !code.includes('{{')) return '';
+      return maskJavaScriptComments(code, getParsedSource(code));
     };
 
     while (stack.length) {

--- a/packages/plugins/@nocobase/plugin-flow-engine/src/server/variables/runjs-variable-dependencies.ts
+++ b/packages/plugins/@nocobase/plugin-flow-engine/src/server/variables/runjs-variable-dependencies.ts
@@ -484,8 +484,9 @@ export function prepareFlowModelVariableSource(
     let sourceCount = 0;
     let totalStringLength = 0;
     let totalSourceLength = 0;
+    const supplementalScripts: string[] = [];
 
-    const prepareRunJsCode = (code: string, version?: string | null, preserveLegacyTemplates = false) => {
+    const extractRunJsDependencies = (code: string) => {
       // AST limits only skip dependency extraction; configured templates still use the model's string budget.
       if (
         sourceCount < MAX_RUNJS_SOURCES_PER_REQUEST &&
@@ -495,11 +496,14 @@ export function prepareFlowModelVariableSource(
         sourceCount += 1;
         totalSourceLength += code.length;
         extractStaticVariableTemplates(code).forEach((template) => templates.add(template));
-      } else if (preserveLegacyTemplates) {
-        // Newly recognized paths previously participated in template scanning even without AST extraction.
-        return maskJavaScriptComments(code);
       }
-      return version === 'v2' ? '' : maskJavaScriptComments(code);
+    };
+
+    const prepareRunJsCode = (code: string, version?: string | null, preserveLegacyTemplates = false) => {
+      // Existing RunJS locations get the budget first, regardless of property traversal order.
+      if (preserveLegacyTemplates) supplementalScripts.push(code);
+      else extractRunJsDependencies(code);
+      return version === 'v2' && !preserveLegacyTemplates ? '' : maskJavaScriptComments(code);
     };
 
     while (stack.length) {
@@ -518,7 +522,7 @@ export function prepareFlowModelVariableSource(
         }
         const prepared =
           typeof input === 'string' && !options.isRunJsValuePath && isPersistedRunJsStringPath(pathTail)
-            ? prepareRunJsCode(input)
+            ? prepareRunJsCode(input, undefined, true)
             : input;
         defineTraversalValue(parent, key, prepared);
         continue;
@@ -583,6 +587,7 @@ export function prepareFlowModelVariableSource(
       }
     }
 
+    supplementalScripts.forEach(extractRunJsDependencies);
     return { ok: true, runJsTemplates: Array.from(templates), templateSource: root.value };
   } catch {
     return { ok: false };

--- a/packages/plugins/@nocobase/plugin-ui-layout/src/client-v2/__tests__/layoutPermissions.test.tsx
+++ b/packages/plugins/@nocobase/plugin-ui-layout/src/client-v2/__tests__/layoutPermissions.test.tsx
@@ -353,6 +353,9 @@ describe('plugin-ui-layout route permissions', () => {
 
     const adminRoute = await screen.findByRole('checkbox', { name: 'Allow access to Admin route' });
     expect(adminRoute).toBeChecked();
+    await waitFor(() => {
+      expect(adminRoute).not.toHaveStyle({ pointerEvents: 'none' });
+    });
 
     await act(async () => {
       await user.click(adminRoute);

--- a/packages/plugins/@nocobase/plugin-ui-templates/src/client-v2/models/__tests__/ReferenceBlockModel.test.tsx
+++ b/packages/plugins/@nocobase/plugin-ui-templates/src/client-v2/models/__tests__/ReferenceBlockModel.test.tsx
@@ -11,6 +11,7 @@ import { FlowEngine, FlowModel, MultiRecordResource, SingleRecordResource } from
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { CollectionBlockModel, FilterManager } from '@nocobase/client-v2';
 import { ReferenceBlockModel } from '../ReferenceBlockModel';
+import type { FlowRuntimeContext } from '@nocobase/flow-engine';
 
 class MockGridModel extends FlowModel {}
 
@@ -1582,7 +1583,7 @@ describe('ReferenceBlockModel', () => {
 
         await referenceBlockModel.dispatchEvent('beforeRender');
 
-        const flowSpy = vi.fn(async () => undefined);
+        const flowSpy = vi.fn(async (ctx: FlowRuntimeContext) => ctx.variableContractModelUid);
         referenceBlockModel.registerFlow({
           key: 'row-click-flow',
           on: {
@@ -1604,6 +1605,8 @@ describe('ReferenceBlockModel', () => {
 
         expect((target.props as any).highlightedRowKey).toBe(1);
         expect(flowSpy).toHaveBeenCalledTimes(1);
+        expect(flowSpy.mock.calls[0][0].model.uid).toBe(target.uid);
+        expect(flowSpy.mock.calls[0][0].variableContractModelUid).toBe(referenceBlockModel.uid);
       },
       TEST_TIMEOUT,
     );


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->
Non-admin users could not resolve configured variables when form linkage rules or referenced events were stored on a different model from the runtime context.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->
Include direct and referenced form-grid linkage rules and persisted RunJS dependencies in the variable allow-list. Preserve the configuration owner for forwarded reference events, and include the validated target model's own configuration and form-grid rules without changing its record context. No permission changes or data migration.

The latest follow-up changes one production file (+11/-3). It replaces the synthetic form-request test with authenticated HTTP coverage, adds delayed-response form-rendering coverage, and fixes the CI permission test's click-before-loading-completes race with a three-line wait. Tests drain automatic linkage refreshes between cases rather than changing default-value behavior: edit-mode defaults do not overwrite existing records; override values still apply.

Verification of the exact committed source tree: [regression run](https://github.com/nocobase/nocobase/actions/runs/34138712346).

| Suite | Files | Passed | Skipped |
| --- | ---: | ---: | ---: |
| Variable server tests | 19 | 364 | 0 |
| Core Flow Engine | 124 | 1634 | 1 existing |
| Template client | 11 | 97 | 0 |
| Form runtime and popup linkage | 14 | 155 | 0 |
| UI layout client | 9 | 186 | 0 |

ESLint and `git diff --check` passed. The permission test file also passed three consecutive reruns (8 tests each). These are the affected regression suites, not a claim that the entire repository or every database/platform matrix has been rerun. The live reported instance was not accessed.

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed non-admin variable resolution in form linkage rules, referenced templates, and scripts. |
| 🇨🇳 Chinese | 修复非管理员用户在表单联动规则、引用模板及脚本中的变量解析问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
