### PR TITLE
fix(plugin-workflow-delay): support variables in duration validation

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow-delay/src/locale/en-US.json
+++ b/packages/plugins/@nocobase/plugin-workflow-delay/src/locale/en-US.json
@@ -2,6 +2,7 @@
   "Delay": "Delay",
   "Delay a period of time and then continue or exit the process. Can be used to set wait or timeout times in parallel branches.": "Delay a period of time and then continue or exit the process. Can be used to set wait or timeout times in parallel branches.",
   "Duration": "Duration",
+  "Delay duration must be a finite number greater than or equal to 1": "Delay duration must be a finite number greater than or equal to 1",
   "Duration must be at least 1": "Duration must be at least 1",
   "End status": "End status",
   "Fail and exit": "Fail and exit",

--- a/packages/plugins/@nocobase/plugin-workflow-delay/src/locale/zh-CN.json
+++ b/packages/plugins/@nocobase/plugin-workflow-delay/src/locale/zh-CN.json
@@ -2,6 +2,7 @@
   "Delay": "延时",
   "Delay a period of time and then continue or exit the process. Can be used to set wait or timeout times in parallel branches.": "延时一段时间，然后继续或退出流程。可以用于并行分支中等待其他分支或设置超时时间。",
   "Duration": "时长",
+  "Delay duration must be a finite number greater than or equal to 1": "延时时长必须是大于或等于 1 的有限数字",
   "Duration must be at least 1": "时长不能小于 1",
   "End status": "到时状态",
   "Fail and exit": "失败并退出",

--- a/packages/plugins/@nocobase/plugin-workflow-delay/src/server/DelayInstruction.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-delay/src/server/DelayInstruction.ts
@@ -20,7 +20,7 @@ type ValueOf<T> = T[keyof T];
 
 interface DelayConfig {
   endStatus: ValueOf<typeof JOB_STATUS>;
-  duration: number;
+  duration: number | string;
   unit: number;
 }
 
@@ -30,7 +30,7 @@ export default class extends Instruction {
   timers: Map<string, NodeJS.Timeout> = new Map();
 
   configSchema = Joi.object({
-    duration: Joi.number().min(1),
+    duration: Joi.alternatives().try(Joi.number().min(1), Joi.string()),
     endStatus: Joi.number().valid(JOB_STATUS.RESOLVED, JOB_STATUS.FAILED),
     unit: Joi.number().valid(...UNITS),
   });

--- a/packages/plugins/@nocobase/plugin-workflow-delay/src/server/DelayInstruction.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-delay/src/server/DelayInstruction.ts
@@ -112,7 +112,11 @@ export default class extends Instruction {
   }
 
   async run(node, prevJob, processor: Processor) {
-    const duration = processor.getParsedValue(node.config.duration || 1, node.id) * (node.config.unit || 1_000);
+    const parsedDuration = processor.getParsedValue(node.config.duration ?? 1, node.id);
+    if (typeof parsedDuration !== 'number' || !Number.isFinite(parsedDuration) || parsedDuration < 1) {
+      throw new Error('Delay duration must be a finite number greater than or equal to 1');
+    }
+    const duration = parsedDuration * (node.config.unit || 1_000);
     const job = processor.saveJob({
       status: JOB_STATUS.PENDING,
       result: duration,

--- a/packages/plugins/@nocobase/plugin-workflow-delay/src/server/DelayInstruction.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-delay/src/server/DelayInstruction.ts
@@ -25,6 +25,7 @@ interface DelayConfig {
 }
 
 const UNITS = [1_000, 60_000, 3_600_000, 86_400_000, 604_800_000];
+const NAMESPACE = 'workflow-delay';
 
 export default class extends Instruction {
   timers: Map<string, NodeJS.Timeout> = new Map();
@@ -114,7 +115,11 @@ export default class extends Instruction {
   async run(node, prevJob, processor: Processor) {
     const parsedDuration = processor.getParsedValue(node.config.duration ?? 1, node.id);
     if (typeof parsedDuration !== 'number' || !Number.isFinite(parsedDuration) || parsedDuration < 1) {
-      throw new Error('Delay duration must be a finite number greater than or equal to 1');
+      throw new Error(
+        this.workflow.app.i18n.t('Delay duration must be a finite number greater than or equal to 1', {
+          ns: NAMESPACE,
+        }),
+      );
     }
     const duration = parsedDuration * (node.config.unit || 1_000);
     const job = processor.saveJob({

--- a/packages/plugins/@nocobase/plugin-workflow-delay/src/server/__tests__/instruction.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-delay/src/server/__tests__/instruction.test.ts
@@ -309,6 +309,20 @@ describe('workflow > instructions > delay', () => {
       expect(status).toBe(200);
     });
 
+    it('should accept duration as a JSON template variable', async () => {
+      const { status } = await agent.resource('workflows.nodes', validationWorkflow.id).create({
+        values: { type: 'delay', config: { duration: '{{$context.data.duration}}' } },
+      });
+      expect(status).toBe(200);
+    });
+
+    it('should reject a numeric duration below the minimum', async () => {
+      const { status } = await agent.resource('workflows.nodes', validationWorkflow.id).create({
+        values: { type: 'delay', config: { duration: 0 } },
+      });
+      expect(status).toBe(400);
+    });
+
     it('should accept with empty config', async () => {
       const { status } = await agent.resource('workflows.nodes', validationWorkflow.id).create({
         values: { type: 'delay', config: {} },

--- a/packages/plugins/@nocobase/plugin-workflow-delay/src/server/__tests__/instruction.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-delay/src/server/__tests__/instruction.test.ts
@@ -179,6 +179,37 @@ describe('workflow > instructions > delay', () => {
       expect(j2.status).toBe(JOB_STATUS.RESOLVED);
     });
 
+    it('should error when the duration variable resolves to a string', async () => {
+      const n1 = await workflow.createNode({
+        type: 'echoVariable',
+        config: {
+          variable: 'invalid duration',
+        },
+      });
+
+      const n2 = await workflow.createNode({
+        type: 'delay',
+        config: {
+          duration: `{{$jobsMapByNodeKey.${n1.key}}}`,
+          unit: 1000,
+          endStatus: JOB_STATUS.RESOLVED,
+        },
+        upstreamId: n1.id,
+      });
+
+      await n1.setDownstream(n2);
+      await PostRepo.create({ values: { title: 't1' } });
+      await sleep(500);
+
+      const [execution] = await workflow.getExecutions();
+      expect(execution.status).toEqual(EXECUTION_STATUS.ERROR);
+      const [, delayJob] = await execution.getJobs({ order: [['id', 'ASC']] });
+      expect(delayJob.status).toBe(JOB_STATUS.ERROR);
+      expect(delayJob.result).toMatchObject({
+        message: 'Delay duration must be a finite number greater than or equal to 1',
+      });
+    });
+
     it('delay to resolve and downstream node error', async () => {
       const n1 = await workflow.createNode({
         type: 'delay',


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
The delay node runtime supports resolving json-templates variables for duration, but its server-side configuration validation only accepted numbers. After allowing template strings to be saved, an invalid resolved value such as a string could also be passed to the timer and leave the workflow waiting unexpectedly.

### Description
- Allow duration to be either a number or a json-templates variable string when saving node configuration.
- Keep the minimum value validation for numeric configuration values.
- Validate the resolved duration at runtime and require a finite number greater than or equal to 1.
- Fail the delay node immediately with a clear error when a variable resolves to an invalid value.
- Add regression tests for valid template variables, invalid string results, and numeric durations below the minimum.

Risk is limited to delay-node duration validation. Valid numeric variables continue to use the existing scheduling behavior.

Testing suggestion: run delay nodes with a numeric variable and with a string variable; the former should wait normally and the latter should immediately enter Error with the validation message.

### Related issues

N/A

### Showcase

N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed delay duration variable validation and report invalid resolved values instead of waiting unexpectedly. |
| 🇨🇳 Chinese | 修复延时节点的时长变量校验，并在变量解析结果无效时直接报错，避免异常等待。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary