### PR TITLE
fix(plugin-notification-in-app-message): allow all variables in message fields

### DIFF
--- a/packages/plugins/@nocobase/plugin-notification-in-app-message/src/client-v2/__tests__/MessageConfigForm.test.tsx
+++ b/packages/plugins/@nocobase/plugin-notification-in-app-message/src/client-v2/__tests__/MessageConfigForm.test.tsx
@@ -17,9 +17,6 @@ const holder = vi.hoisted(() => ({
   inputs: [] as Array<{ metaTree?: MetaTreeNode[] }>,
   textAreas: [] as Array<{ metaTree?: MetaTreeNode[] }>,
   userSelects: [] as Array<{ variableOptions?: MetaTreeNode[] }>,
-  stringMetaTree: [
-    { name: '$context', title: 'String variables', type: 'object', paths: ['$context'], children: [] },
-  ] as MetaTreeNode[],
   userMetaTree: [
     { name: '$context', title: 'User variables', type: 'object', paths: ['$context'], children: [] },
   ] as MetaTreeNode[],
@@ -85,14 +82,10 @@ describe('in-app-message MessageConfigForm (v2)', () => {
     holder.inputs.length = 0;
     holder.textAreas.length = 0;
     holder.userSelects.length = 0;
-    holder.useWorkflowVariableOptions
-      .mockReset()
-      .mockImplementation((options: { types?: unknown[] }) =>
-        options.types?.[0] === 'string' ? holder.stringMetaTree : holder.userMetaTree,
-      );
+    holder.useWorkflowVariableOptions.mockReset().mockReturnValue(holder.userMetaTree);
   });
 
-  it('computes filtered variables once per type and reuses them across matching fields', () => {
+  it('only filters receivers while allowing every variable type in title, links, and content', () => {
     render(
       <Form initialValues={{ config: { receivers: [''] } }}>
         <MessageConfigForm namePrefix={['config']} variableOptions={META_TREE} />
@@ -102,15 +95,15 @@ describe('in-app-message MessageConfigForm (v2)', () => {
     expect(holder.inputs.length).toBeGreaterThanOrEqual(3);
     expect(holder.textAreas.length).toBeGreaterThanOrEqual(1);
     expect(holder.userSelects.length).toBeGreaterThanOrEqual(1);
-    for (const props of holder.inputs) {
-      expect(props.metaTree).toBe(holder.stringMetaTree);
-    }
+    expect(holder.inputs[0].metaTree).toBe(META_TREE);
+    expect(holder.inputs[1].metaTree).toBe(META_TREE);
+    expect(holder.inputs[2].metaTree).toBe(META_TREE);
     for (const props of holder.textAreas) {
       expect(props.metaTree).toBe(META_TREE);
     }
     for (const props of holder.userSelects) {
       expect(props.variableOptions).toBe(holder.userMetaTree);
     }
-    expect(holder.useWorkflowVariableOptions).toHaveBeenCalledTimes(2);
+    expect(holder.useWorkflowVariableOptions).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/plugins/@nocobase/plugin-notification-in-app-message/src/client-v2/components/ContentConfigForm.tsx
+++ b/packages/plugins/@nocobase/plugin-notification-in-app-message/src/client-v2/components/ContentConfigForm.tsx
@@ -32,7 +32,7 @@ export function ContentConfigForm(props: ContentConfigFormProps) {
         label={t('Message title')}
         rules={[{ required: true, message: t('The field value is required') }]}
       >
-        <WorkflowVariableInput metaTree={variableOptions} variableOptions={{ types: ['string'] }} />
+        <WorkflowVariableInput metaTree={variableOptions} />
       </Form.Item>
       <Form.Item
         name={withPrefix(props.namePrefix, 'content')}
@@ -53,7 +53,7 @@ export function ContentConfigForm(props: ContentConfigFormProps) {
           'Support two types of links: internal links and external links. If using an internal link, the link starts with "/", for example, "/admin". If using an external link, the link starts with "http", for example, "https://example.com".',
         )}
       >
-        <WorkflowVariableInput metaTree={variableOptions} variableOptions={{ types: ['string'] }} />
+        <WorkflowVariableInput metaTree={variableOptions} />
       </Form.Item>
       <Form.Item
         name={withPrefix(props.namePrefix, 'options', 'mobileUrl')}
@@ -62,7 +62,7 @@ export function ContentConfigForm(props: ContentConfigFormProps) {
           'Support two types of links: internal links and external links. If using an internal link, the link starts with "/", for example, "/m". If using an external link, the link starts with "http", for example, "https://example.com".',
         )}
       >
-        <WorkflowVariableInput metaTree={variableOptions} variableOptions={{ types: ['string'] }} />
+        <WorkflowVariableInput metaTree={variableOptions} />
       </Form.Item>
       <Form.Item
         name={withPrefix(props.namePrefix, 'options', 'duration')}

--- a/packages/plugins/@nocobase/plugin-notification-in-app-message/src/client-v2/components/MessageConfigForm.tsx
+++ b/packages/plugins/@nocobase/plugin-notification-in-app-message/src/client-v2/components/MessageConfigForm.tsx
@@ -81,7 +81,6 @@ function ReceiverSortHandle() {
 }
 
 type MessageConfigFormContentProps = MessageConfigFormProps & {
-  stringVariableOptions: MetaTreeNode[];
   userVariableOptions: MetaTreeNode[];
 };
 
@@ -179,7 +178,7 @@ function MessageConfigFormContent(props: MessageConfigFormContentProps) {
         label={t('Message title')}
         rules={[{ required: true, message: t('The field value is required') }]}
       >
-        <WorkflowVariableInput metaTree={props.stringVariableOptions} />
+        <WorkflowVariableInput metaTree={props.variableOptions} />
       </Form.Item>
       <Form.Item
         name={withPrefix(props.namePrefix, 'content')}
@@ -200,7 +199,7 @@ function MessageConfigFormContent(props: MessageConfigFormContentProps) {
           'Support two types of links: internal links and external links. If using an internal link, the link starts with "/", for example, "/admin". If using an external link, the link starts with "http", for example, "https://example.com".',
         )}
       >
-        <WorkflowVariableInput metaTree={props.stringVariableOptions} />
+        <WorkflowVariableInput metaTree={props.variableOptions} />
       </Form.Item>
       <Form.Item
         name={withPrefix(props.namePrefix, 'options', 'mobileUrl')}
@@ -209,7 +208,7 @@ function MessageConfigFormContent(props: MessageConfigFormContentProps) {
           'Support two types of links: internal links and external links. If using an internal link, the link starts with "/", for example, "/m". If using an external link, the link starts with "http", for example, "https://example.com".',
         )}
       >
-        <WorkflowVariableInput metaTree={props.stringVariableOptions} />
+        <WorkflowVariableInput metaTree={props.variableOptions} />
       </Form.Item>
       <Form.Item
         name={withPrefix(props.namePrefix, 'options', 'duration')}
@@ -224,16 +223,9 @@ function MessageConfigFormContent(props: MessageConfigFormContentProps) {
 }
 
 export function MessageConfigForm(props: MessageConfigFormProps) {
-  const stringVariableOptions = useWorkflowVariableOptions({ types: ['string'] });
   const userVariableOptions = useWorkflowVariableOptions({ types: [isUserKeyField] });
 
-  return (
-    <MessageConfigFormContent
-      {...props}
-      stringVariableOptions={stringVariableOptions}
-      userVariableOptions={userVariableOptions}
-    />
-  );
+  return <MessageConfigFormContent {...props} userVariableOptions={userVariableOptions} />;
 }
 
 export default MessageConfigForm;


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

The v2 migration of the workflow notification form changed the legacy typed-constant setting into a variable-tree type filter. As a result, message titles and in-app message links only exposed string-interface fields, preventing valid values such as record IDs from being used in URL templates.

### Description

- Remove the string-only variable filter from in-app message titles.
- Remove the string-only variable filter from desktop and mobile detail links.
- Keep the user-ID-specific filter for receivers unchanged.
- Update the form test to verify that title, content, and links reuse the complete workflow variable tree.

Risk is limited to allowing users to select additional variable types in string templates. Variable conversion and template evaluation remain unchanged.

Testing:

- `yarn test packages/plugins/@nocobase/plugin-notification-in-app-message/src/client-v2/__tests__/MessageConfigForm.test.tsx --run --reporter=verbose`
- `yarn test packages/plugins/@nocobase/plugin-notification-in-app-message/src/client-v2/__tests__/ContentConfigForm.test.tsx --run --reporter=verbose`
- `yarn eslint --fix` on all touched files

### Related issues

N/A

### Showcase

N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Allow all workflow variable types in in-app notification titles and detail links. |
| 🇨🇳 Chinese | 允许在站内信通知的标题和详情链接中使用所有类型的工作流变量。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
