### PR TITLE
fix(plugin-data-source-manager): support variables in v2 permission scopes

### DIFF
--- a/packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/permissions/ScopeSelect.tsx
+++ b/packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/permissions/ScopeSelect.tsx
@@ -7,15 +7,22 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import { CollectionFilterPanel, DrawerFormLayout, Table, type CollectionFilterPanelRef } from '@nocobase/client-v2';
-import type { Collection } from '@nocobase/flow-engine';
-import { useFlowContext } from '@nocobase/flow-engine';
+import {
+  DrawerFormLayout,
+  FilterGroup,
+  Table,
+  VariableFilterItem,
+  type CompiledFilter,
+  type VariableFilterItemValue,
+} from '@nocobase/client-v2';
+import type { Collection, Converters, FlowEngineContext, MetaTreeNode } from '@nocobase/flow-engine';
+import { FlowModel, FlowModelProvider, observable, randomId, useFlowContext } from '@nocobase/flow-engine';
 import { PlusOutlined } from '@ant-design/icons';
 import { css } from '@emotion/css';
 import { useMemoizedFn, useRequest } from 'ahooks';
 import { App, Button, Form, Input, Select, Space, theme, Tooltip } from 'antd';
 import type { ColumnsType, TablePaginationConfig } from 'antd/es/table';
-import React, { useMemo, useRef, useState } from 'react';
+import React, { forwardRef, useEffect, useImperativeHandle, useMemo, useRef, useState } from 'react';
 import { compileLegacyTemplate, compileLegacyTemplateText } from '../../utils/compileLegacyTemplate';
 import {
   destroyScopeRecord,
@@ -30,6 +37,200 @@ type TFunction = (key: string, options?: Record<string, unknown>) => string;
 
 const DATA_SCOPE_PAGE_SIZE = 20;
 const DATA_SCOPE_DRAWER_WIDTH = '50%';
+
+type PermissionFilterGroupItem = VariableFilterItemValue | PermissionFilterGroupValue;
+
+interface PermissionFilterGroupValue {
+  logic: '$and' | '$or';
+  items: PermissionFilterGroupItem[];
+}
+
+interface PermissionScopeFilterRef {
+  getFilter: () => CompiledFilter;
+}
+
+function isFilterGroup(item: PermissionFilterGroupItem): item is PermissionFilterGroupValue {
+  return Array.isArray((item as PermissionFilterGroupValue).items);
+}
+
+function nestFilterPath(path: string, leaf: unknown) {
+  const segments = path.split('.');
+  let result: unknown = leaf;
+  for (let index = segments.length - 1; index >= 0; index -= 1) {
+    result = { [segments[index]]: result };
+  }
+  return result as Record<string, unknown>;
+}
+
+function isEmptyFilterValue(value: VariableFilterItemValue['value']) {
+  if (value === undefined || value === null || value === '') {
+    return true;
+  }
+  if (Array.isArray(value)) {
+    return value.length === 0;
+  }
+  return typeof value === 'object' && Object.keys(value).length === 0;
+}
+
+function compilePermissionFilter(group: PermissionFilterGroupValue | undefined): CompiledFilter {
+  if (!group?.items.length) {
+    return undefined;
+  }
+  const items = group.items
+    .map((item) => {
+      if (isFilterGroup(item)) {
+        return compilePermissionFilter(item);
+      }
+      if (!item.path || !item.operator || isEmptyFilterValue(item.value)) {
+        return undefined;
+      }
+      return nestFilterPath(item.path, { [item.operator]: item.value });
+    })
+    .filter((item): item is Record<string, unknown> => Boolean(item));
+  return items.length ? { [group.logic]: items } : undefined;
+}
+
+function decompilePermissionConditions(value: unknown, path: string[] = []): PermissionFilterGroupItem[] {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return path.length
+      ? [{ path: path.join('.'), operator: '$eq', value: value as VariableFilterItemValue['value'] }]
+      : [];
+  }
+  const entries = Object.entries(value as Record<string, unknown>);
+  const operatorEntries = entries.filter(([key]) => key.startsWith('$'));
+  if (operatorEntries.length) {
+    return operatorEntries.map(([operator, operatorValue]) => ({
+      path: path.join('.'),
+      operator,
+      value: operatorValue as VariableFilterItemValue['value'],
+    }));
+  }
+  return entries.flatMap(([fieldName, nextValue]) => decompilePermissionConditions(nextValue, [...path, fieldName]));
+}
+
+function decompilePermissionFilter(filter: CompiledFilter): PermissionFilterGroupValue {
+  if (!filter || typeof filter !== 'object' || Array.isArray(filter)) {
+    return { logic: '$and', items: [] };
+  }
+  const record = filter as Record<string, unknown>;
+  const logic = Array.isArray(record.$or) ? '$or' : '$and';
+  const sourceItems = Array.isArray(record[logic]) ? (record[logic] as unknown[]) : [record];
+  return {
+    logic,
+    items: sourceItems.flatMap((item) => {
+      if (!item || typeof item !== 'object' || Array.isArray(item)) {
+        return [];
+      }
+      const nested = item as Record<string, unknown>;
+      if (Array.isArray(nested.$and) || Array.isArray(nested.$or)) {
+        return [decompilePermissionFilter(nested)];
+      }
+      return decompilePermissionConditions(nested);
+    }),
+  };
+}
+
+const permissionVariableConverters: Pick<Converters, 'resolvePathFromValue' | 'resolveValueFromPath'> = {
+  resolvePathFromValue(value) {
+    if (typeof value !== 'string') {
+      return undefined;
+    }
+    const expression = value.match(/^\{\{\s*([^}]+?)\s*\}\}$/)?.[1];
+    if (!expression) {
+      return undefined;
+    }
+    if (expression === '$nRole' || expression === 'ctx.state.currentRole') {
+      return ['role'];
+    }
+    const userMatch = expression.match(/^(?:\$user|ctx\.state\.currentUser)(?:\.(.+))?$/);
+    return userMatch ? ['user', ...(userMatch[1] ? userMatch[1].split('.') : [])] : undefined;
+  },
+  resolveValueFromPath(metaTreeNode) {
+    const [root, ...path] = metaTreeNode.paths;
+    if (root === 'role') {
+      return '{{$nRole}}';
+    }
+    if (root === 'user' && path.length) {
+      return `{{$user.${path.join('.')}}}`;
+    }
+    return undefined;
+  },
+};
+
+interface PermissionScopeFilterProps {
+  collection: Collection | undefined;
+  initialValue?: CompiledFilter;
+}
+
+const PermissionScopeFilter = forwardRef<PermissionScopeFilterRef, PermissionScopeFilterProps>((props, ref) => {
+  const ctx = useFlowContext<FlowEngineContext>();
+  const [model, setModel] = useState<FlowModel>();
+  const filterValueRef = useRef<PermissionFilterGroupValue>();
+  if (!filterValueRef.current) {
+    filterValueRef.current = observable(decompilePermissionFilter(props.initialValue)) as PermissionFilterGroupValue;
+  }
+
+  useEffect(() => {
+    if (!props.collection) {
+      setModel(undefined);
+      return;
+    }
+    const nextModel = ctx.engine.createModel<FlowModel>({
+      uid: randomId('permissionScopeFilter_'),
+      use: FlowModel,
+    });
+    nextModel.context.defineProperty('collection', { value: props.collection });
+    setModel(nextModel);
+
+    return () => {
+      nextModel.remove();
+    };
+  }, [ctx.engine, props.collection]);
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      getFilter: () => compilePermissionFilter(filterValueRef.current),
+    }),
+    [],
+  );
+
+  const rightMetaTree = useMemo(
+    () => async () => {
+      if (!model) {
+        return [];
+      }
+      const tree = await model.context.getPropertyMetaTree();
+      return tree
+        .filter((node: MetaTreeNode) => node.name === 'user' || node.name === 'role')
+        .map((node: MetaTreeNode) => (node.name === 'user' ? { ...node, selectable: false } : node));
+    },
+    [model],
+  );
+
+  if (!model) {
+    return null;
+  }
+
+  return (
+    <FilterGroup
+      value={filterValueRef.current}
+      FilterItem={(itemProps) => (
+        <FlowModelProvider model={model}>
+          <VariableFilterItem
+            {...itemProps}
+            model={model}
+            rightAsVariable
+            rightMetaTree={rightMetaTree}
+            rightVariableConverters={permissionVariableConverters}
+          />
+        </FlowModelProvider>
+      )}
+    />
+  );
+});
+
+PermissionScopeFilter.displayName = 'PermissionScopeFilter';
 
 function normalizeListResponse(response: any) {
   const payload = response?.data?.data;
@@ -130,9 +331,9 @@ interface ScopeFormProps {
 }
 
 function ScopeForm(props: ScopeFormProps) {
-  const ctx = useFlowContext();
+  const ctx = useFlowContext<FlowEngineContext>();
   const [form] = Form.useForm();
-  const filterPanelRef = useRef<CollectionFilterPanelRef>(null);
+  const filterPanelRef = useRef<PermissionScopeFilterRef>(null);
   const resource = useMemo(
     () =>
       ctx.api.resource(`dataSources/${props.dataSourceKey}/rolesResourcesScopes`) as unknown as CreateUpdateResource,
@@ -166,12 +367,10 @@ function ScopeForm(props: ScopeFormProps) {
           <Input />
         </Form.Item>
         <Form.Item label={props.t('Data scope')}>
-          <CollectionFilterPanel
+          <PermissionScopeFilter
             ref={filterPanelRef}
             collection={props.collection}
             initialValue={props.initialValues?.scope}
-            t={props.t}
-            noIgnore
           />
         </Form.Item>
       </Form>

--- a/packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/permissions/__tests__/ScopeSelect.test.tsx
+++ b/packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/permissions/__tests__/ScopeSelect.test.tsx
@@ -10,6 +10,7 @@
 import React from 'react';
 import { App } from 'antd';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { Collection } from '@nocobase/flow-engine';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const scopeResource = {
@@ -34,6 +35,12 @@ const scopeResource = {
               key: 'custom',
               name: '{{t("Custom scope")}}',
               resourceName: 'orders',
+              scope: {
+                $and: [
+                  { createdById: { $eq: '{{ ctx.state.currentUser.id }}' } },
+                  { roleName: { $eq: '{{ ctx.state.currentRole }}' } },
+                ],
+              },
             },
             {
               id: 2,
@@ -49,12 +56,41 @@ const scopeResource = {
       },
     }),
   ),
+  create: vi.fn(() => Promise.resolve()),
+  update: vi.fn(() => Promise.resolve()),
 };
 
+interface VariableFilterProps {
+  rightAsVariable?: boolean;
+  rightMetaTree?: () => Promise<Array<{ name: string }>>;
+  rightVariableConverters?: {
+    resolvePathFromValue?: (value: unknown) => string[] | undefined;
+    resolveValueFromPath?: (node: { paths: string[] }) => unknown;
+  };
+}
+
 const flowMocks = {
+  variableFilterProps: null as VariableFilterProps | null,
+  filterGroupValue: null as null | {
+    items: Array<{ path: string; operator: string; value: unknown }>;
+  },
+  filterModel: {
+    context: {
+      defineProperty: vi.fn(),
+      getPropertyMetaTree: vi.fn(() => [
+        { name: 'user', paths: ['user'] },
+        { name: 'role', paths: ['role'] },
+        { name: 'formValues', paths: ['formValues'] },
+      ]),
+    },
+    remove: vi.fn(),
+  },
   ctx: {
     api: {
       resource: vi.fn(() => scopeResource),
+    },
+    engine: {
+      createModel: vi.fn(),
     },
     viewer: {
       drawer: vi.fn(),
@@ -74,24 +110,38 @@ vi.mock('@nocobase/client-v2', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@nocobase/client-v2')>();
   return {
     ...actual,
-    CollectionFilterPanel: React.forwardRef((_props, ref) => {
-      React.useImperativeHandle(ref, () => ({
-        getFilter: () => ({ status: 'active' }),
-      }));
-      return <div data-testid="collection-filter-panel" />;
-    }),
+    FilterGroup: ({
+      FilterItem,
+      value,
+    }: {
+      FilterItem?: React.ComponentType<{ value: Record<string, unknown> }>;
+      value: { items: Array<{ path: string; operator: string; value: unknown }> };
+    }) => {
+      flowMocks.filterGroupValue = value;
+      if (!value.items.length) {
+        value.items.push({ path: '', operator: '', value: '' });
+      }
+      return <div data-testid="filter-group">{FilterItem ? <FilterItem value={value.items[0]} /> : null}</div>;
+    },
+    VariableFilterItem: (props: VariableFilterProps) => {
+      flowMocks.variableFilterProps = props;
+      return <div data-testid="variable-filter-item" data-right-as-variable={String(Boolean(props.rightAsVariable))} />;
+    },
     DrawerFormLayout: ({
       children,
       footer,
       title,
+      onSubmit,
     }: {
       children: React.ReactNode;
       footer?: React.ReactNode;
       title: string;
+      onSubmit?: () => void | Promise<void>;
     }) => (
       <section aria-label={title}>
         {children}
         {footer}
+        {onSubmit ? <button onClick={onSubmit}>Submit {title}</button> : null}
       </section>
     ),
     Table: ({
@@ -135,6 +185,9 @@ const t = (key: string) => `t:${key}`;
 describe('ScopeSelect', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    flowMocks.variableFilterProps = null;
+    flowMocks.filterGroupValue = null;
+    flowMocks.ctx.engine.createModel.mockReturnValue(flowMocks.filterModel);
   });
 
   it('loads the selected scope record when value only contains an id', async () => {
@@ -178,5 +231,102 @@ describe('ScopeSelect', () => {
       }),
     );
     expect(close).toHaveBeenCalled();
+  });
+
+  it('provides variable selection when creating a permission data scope', async () => {
+    const collection = new Collection({ name: 'orders' });
+    render(
+      <App>
+        <ScopeSelect collection={collection} dataSourceKey="main" resourceName="orders" t={t} />
+      </App>,
+    );
+
+    fireEvent.click(screen.getByRole('combobox'));
+    const pickerConfig = flowMocks.ctx.viewer.drawer.mock.calls[0][0];
+    render(<App>{pickerConfig.content({ close: vi.fn() })}</App>);
+
+    fireEvent.click(await screen.findByText('t:Add new'));
+    const scopeFormConfig = flowMocks.ctx.viewer.drawer.mock.calls[1][0];
+    const scopeFormView = render(<App>{scopeFormConfig.content()}</App>);
+
+    expect(screen.getByTestId('variable-filter-item')).toHaveAttribute('data-right-as-variable', 'true');
+    await expect(flowMocks.variableFilterProps?.rightMetaTree?.()).resolves.toEqual([
+      expect.objectContaining({ name: 'user' }),
+      expect.objectContaining({ name: 'role' }),
+    ]);
+    expect(
+      flowMocks.variableFilterProps?.rightVariableConverters?.resolveValueFromPath?.({ paths: ['user', 'id'] }),
+    ).toBe('{{$user.id}}');
+    expect(flowMocks.variableFilterProps?.rightVariableConverters?.resolveValueFromPath?.({ paths: ['role'] })).toBe(
+      '{{$nRole}}',
+    );
+    expect(
+      flowMocks.variableFilterProps?.rightVariableConverters?.resolvePathFromValue?.(
+        '{{ ctx.state.currentUser.department.id }}',
+      ),
+    ).toEqual(['user', 'department', 'id']);
+    expect(
+      flowMocks.variableFilterProps?.rightVariableConverters?.resolvePathFromValue?.('{{ ctx.state.currentRole }}'),
+    ).toEqual(['role']);
+
+    if (!flowMocks.filterGroupValue) {
+      throw new Error('Expected the permission filter group to render');
+    }
+    Object.assign(flowMocks.filterGroupValue.items[0], {
+      path: 'createdById',
+      operator: '$eq',
+      value: '{{$user.id}}',
+    });
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'Current user records' } });
+    fireEvent.click(screen.getByText('Submit t:Add record'));
+
+    await waitFor(() =>
+      expect(scopeResource.create).toHaveBeenCalledWith({
+        values: {
+          name: 'Current user records',
+          resourceName: 'orders',
+          scope: {
+            $and: [{ createdById: { $eq: '{{$user.id}}' } }],
+          },
+        },
+      }),
+    );
+
+    scopeFormView.unmount();
+    expect(flowMocks.filterModel.remove).toHaveBeenCalled();
+  });
+
+  it('preserves legacy variable expressions when editing a permission data scope', async () => {
+    const collection = new Collection({ name: 'orders' });
+    render(
+      <App>
+        <ScopeSelect collection={collection} dataSourceKey="main" resourceName="orders" t={t} />
+      </App>,
+    );
+
+    fireEvent.click(screen.getByRole('combobox'));
+    const pickerConfig = flowMocks.ctx.viewer.drawer.mock.calls[0][0];
+    render(<App>{pickerConfig.content({ close: vi.fn() })}</App>);
+
+    fireEvent.click((await screen.findAllByText('t:Edit'))[0]);
+    const scopeFormConfig = flowMocks.ctx.viewer.drawer.mock.calls[1][0];
+    render(<App>{scopeFormConfig.content()}</App>);
+    fireEvent.click(await screen.findByText('Submit t:Edit record'));
+
+    await waitFor(() =>
+      expect(scopeResource.update).toHaveBeenCalledWith({
+        filterByTk: 1,
+        values: {
+          name: '{{t("Custom scope")}}',
+          resourceName: 'orders',
+          scope: {
+            $and: [
+              { createdById: { $eq: '{{ ctx.state.currentUser.id }}' } },
+              { roleName: { $eq: '{{ ctx.state.currentRole }}' } },
+            ],
+          },
+        },
+      }),
+    );
   });
 });


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

The v2 role permission page only allowed constant values when configuring a data scope. This prevented administrators from defining permission filters based on the current user or current role.

### Description

- Add variable selection to the v2 permission data-scope filter.
- Expose only the current user and current role variables for this permission context.
- Persist new selections as `{{$user...}}` and `{{$nRole}}` while preserving legacy `ctx.state.currentUser` and `ctx.state.currentRole` expressions.
- Manage the temporary filter model through the React effect lifecycle.
- Add regression coverage for variable filtering, create serialization, legacy edit round-trips, and model cleanup.

Testing:

- `yarn test packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/permissions/__tests__/ScopeSelect.test.tsx --run --reporter=verbose`
- `yarn test packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/permissions/__tests__/PermissionEditors.test.ts --run --reporter=verbose`
- `yarn test packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/permissions/__tests__/DataSourcePermissionsTab.test.tsx --run --reporter=verbose`
- TypeScript focused check and ESLint on the changed files

### Related issues

N/A

### Showcase

N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Added current user and current role variable selection to v2 permission data scopes |
| 🇨🇳 Chinese | 为 v2 权限数据范围新增当前用户和当前角色变量选择 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
