### PR TITLE
fix(acl): select all parent menu permissions

### DIFF
--- a/packages/plugins/@nocobase/plugin-acl/src/client/permissions/MenuPermissions.tsx
+++ b/packages/plugins/@nocobase/plugin-acl/src/client/permissions/MenuPermissions.tsx
@@ -31,13 +31,13 @@ interface MenuItem {
   parent?: MenuItem;
 }
 
-const toItems = (items, parent?: MenuItem): MenuItem[] => {
+const toItems = (items: MenuItem[], parent?: MenuItem): MenuItem[] => {
   if (!Array.isArray(items)) {
     return [];
   }
 
   return items.map((item) => {
-    const children = toItems(item.children, item);
+    const children = toItems(item.children, { ...item, parent });
     const hideChildren = children.length === 0;
 
     return {
@@ -51,11 +51,11 @@ const toItems = (items, parent?: MenuItem): MenuItem[] => {
   });
 };
 
-const getAllChildrenId = (items) => {
+const getAllChildrenId = (items: MenuItem[]): number[] => {
   if (!Array.isArray(items)) {
     return [];
   }
-  const IDList = [];
+  const IDList: number[] = [];
   for (const item of items) {
     IDList.push(item.id);
     IDList.push(...getAllChildrenId(item.children));
@@ -154,7 +154,7 @@ export const MenuPermissions: React.FC<{
   const api = useAPIClient();
   const { t } = useTranslation();
   const allIDList = getAllChildrenId(items);
-  const [IDList, setIDList] = useState([]);
+  const [IDList, setIDList] = useState<number[]>([]);
   const { loading, refresh } = useRequest(
     {
       resource: 'roles.desktopRoutes',
@@ -180,7 +180,7 @@ export const MenuPermissions: React.FC<{
   const allChecked = allIDList.length === IDList.length;
   const { refresh: refreshDesktopRoutes } = useAllAccessDesktopRoutes();
 
-  const handleChange = async (checked, menuItem) => {
+  const handleChange = async (checked: boolean, menuItem: MenuItem) => {
     // 处理取消选中
     if (checked) {
       let newIDList = IDList.filter((id) => id !== menuItem.id);
@@ -209,11 +209,13 @@ export const MenuPermissions: React.FC<{
       const newIDList = [...IDList, menuItem.id];
       const shouldAdd = [menuItem.id];
 
-      if (menuItem.parent) {
-        if (!newIDList.includes(menuItem.parent.id)) {
-          newIDList.push(menuItem.parent.id);
-          shouldAdd.push(menuItem.parent.id);
+      let parent = menuItem.parent;
+      while (parent) {
+        if (!newIDList.includes(parent.id)) {
+          newIDList.push(parent.id);
+          shouldAdd.push(parent.id);
         }
+        parent = parent.parent;
       }
 
       if (menuItem.children) {
@@ -224,7 +226,7 @@ export const MenuPermissions: React.FC<{
 
       setIDList(uniq(newIDList));
       await resource.add({
-        values: shouldAdd,
+        values: uniq(shouldAdd).filter((id) => !IDList.includes(id)),
       });
     }
     refreshDesktopRoutes();

--- a/packages/plugins/@nocobase/plugin-acl/src/client/permissions/MenuPermissions.tsx
+++ b/packages/plugins/@nocobase/plugin-acl/src/client/permissions/MenuPermissions.tsx
@@ -27,11 +27,11 @@ import { RolesManagerContext } from '../RolesManagerProvider';
 interface MenuItem {
   title: string;
   id: number;
-  children?: MenuItem[];
+  children?: MenuItem[] | null;
   parent?: MenuItem;
 }
 
-const toItems = (items: MenuItem[], parent?: MenuItem): MenuItem[] => {
+const toItems = (items: MenuItem[] | null | undefined, parent?: MenuItem): MenuItem[] => {
   if (!Array.isArray(items)) {
     return [];
   }
@@ -51,7 +51,7 @@ const toItems = (items: MenuItem[], parent?: MenuItem): MenuItem[] => {
   });
 };
 
-const getAllChildrenId = (items: MenuItem[]): number[] => {
+const getAllChildrenId = (items: MenuItem[] | null | undefined): number[] => {
   if (!Array.isArray(items)) {
     return [];
   }
@@ -186,12 +186,14 @@ export const MenuPermissions: React.FC<{
       let newIDList = IDList.filter((id) => id !== menuItem.id);
       const shouldRemove = [menuItem.id];
 
-      if (menuItem.parent) {
-        const selectedChildren = menuItem.parent.children.filter((item) => newIDList.includes(item.id));
-        if (selectedChildren.length === 0) {
-          newIDList = newIDList.filter((id) => id !== menuItem.parent.id);
-          shouldRemove.push(menuItem.parent.id);
+      let parent = menuItem.parent;
+      while (parent) {
+        if (parent.children?.some((item) => newIDList.includes(item.id))) {
+          break;
         }
+        newIDList = newIDList.filter((id) => id !== parent.id);
+        shouldRemove.push(parent.id);
+        parent = parent.parent;
       }
 
       if (menuItem.children) {

--- a/packages/plugins/@nocobase/plugin-acl/src/client/permissions/MenuPermissions.tsx
+++ b/packages/plugins/@nocobase/plugin-acl/src/client/permissions/MenuPermissions.tsx
@@ -274,7 +274,7 @@ export const MenuPermissions: React.FC<{
           },
         }}
       />
-      <Table
+      <Table<MenuItem>
         className={style}
         loading={loading}
         rowKey={'id'}
@@ -317,7 +317,7 @@ export const MenuPermissions: React.FC<{
                 return <Checkbox checked={checked} onChange={() => handleChange(checked, schema)} />;
               },
             },
-          ] as TableProps['columns']
+          ] as TableProps<MenuItem>['columns']
         }
         dataSource={translateTitle(items, t, compile)}
       />

--- a/packages/plugins/@nocobase/plugin-acl/src/client/permissions/__tests__/MenuPermissions.test.tsx
+++ b/packages/plugins/@nocobase/plugin-acl/src/client/permissions/__tests__/MenuPermissions.test.tsx
@@ -7,7 +7,7 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import { fireEvent, render, screen, waitFor } from '@nocobase/test/client';
+import { fireEvent, render, screen, waitFor, within } from '@nocobase/test/client';
 import { App } from 'antd';
 import React from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -17,6 +17,7 @@ import { DesktopAllRoutesProvider, MenuPermissions } from '../MenuPermissions';
 interface MockRoute {
   id: number;
   title: string;
+  children?: MockRoute[];
 }
 
 interface RouteFilter {
@@ -61,6 +62,7 @@ const mocks = vi.hoisted(() => {
     rolesDesktopRoutesRemove: vi.fn(),
     rolesListRequests: [] as RolesDesktopRoutesListRequest[],
     setRole: vi.fn(),
+    selectedRoutes: [] as MockRoute[],
   };
 });
 
@@ -109,7 +111,7 @@ vi.mock('@nocobase/client', async () => {
 
         if (typeof service !== 'function' && service?.resource === 'roles.desktopRoutes') {
           mocks.rolesListRequests.push(service);
-          optionsRef.current.onSuccess?.({ data: [] });
+          optionsRef.current.onSuccess?.({ data: mocks.selectedRoutes });
         }
       }, []);
 
@@ -176,6 +178,7 @@ describe('MenuPermissions', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.rolesListRequests.length = 0;
+    mocks.selectedRoutes = [];
     mocks.desktopRoutesList.mockImplementation(({ filter }) => {
       const routeList =
         filter?.['uiLayouts.uid'] === 'admin-layout-model' ? [mocks.adminRoute] : [mocks.adminRoute, mocks.portalRoute];
@@ -230,6 +233,58 @@ describe('MenuPermissions', () => {
       expect(mocks.rolesDesktopRoutesSet).toHaveBeenCalledWith({
         values: [mocks.adminRoute.id],
       });
+    });
+  });
+
+  it('selects and saves every ancestor when a deeply nested route is checked', async () => {
+    mocks.desktopRoutesList.mockResolvedValue({
+      data: {
+        data: [
+          {
+            id: 10,
+            title: 'Root',
+            children: [
+              {
+                id: 11,
+                title: 'Group',
+                children: [
+                  { id: 12, title: 'Page', children: [{ id: 13, title: 'Tab' }] },
+                  { id: 14, title: 'Sibling' },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    });
+    renderMenuPermissions();
+    for (const name of ['Root', 'Group', 'Page']) {
+      const row = (await screen.findByText(name)).closest('tr');
+      fireEvent.click(within(row).getByRole('button', { name: 'Expand row' }));
+    }
+    fireEvent.click(within(screen.getByRole('row', { name: 'Tab', exact: true })).getByRole('checkbox'));
+
+    await waitFor(() => {
+      expect(mocks.rolesDesktopRoutesAdd).toHaveBeenCalledWith({ values: [13, 12, 11, 10] });
+    });
+    for (const name of ['Root', 'Group', 'Page', 'Tab']) {
+      expect(within(screen.getByText(name).closest('tr')).getByRole('checkbox')).toBeChecked();
+    }
+    expect(within(screen.getByText('Sibling').closest('tr')).getByRole('checkbox')).not.toBeChecked();
+  });
+
+  it('does not add already accessible descendants again when checking their parent', async () => {
+    const child = { id: 11, title: 'Child' };
+    mocks.selectedRoutes = [child];
+    mocks.desktopRoutesList.mockResolvedValue({
+      data: { data: [{ id: 10, title: 'Root', children: [child, { id: 12, title: 'Other child' }] }] },
+    });
+    renderMenuPermissions();
+    const row = (await screen.findByText('Root')).closest('tr');
+    fireEvent.click(within(row).getByRole('checkbox'));
+
+    await waitFor(() => {
+      expect(mocks.rolesDesktopRoutesAdd).toHaveBeenCalledWith({ values: [10, 12] });
     });
   });
 });

--- a/packages/plugins/@nocobase/plugin-acl/src/client/permissions/__tests__/MenuPermissions.test.tsx
+++ b/packages/plugins/@nocobase/plugin-acl/src/client/permissions/__tests__/MenuPermissions.test.tsx
@@ -273,6 +273,41 @@ describe('MenuPermissions', () => {
     expect(within(screen.getByText('Sibling').closest('tr')).getByRole('checkbox')).not.toBeChecked();
   });
 
+  it.each([false, true])(
+    'removes empty ancestors while preserving selected siblings (sibling selected: %s)',
+    async (hasSibling) => {
+      const leaf = { id: 13, title: 'Leaf' };
+      const page = { id: 12, title: 'Page', children: [leaf] };
+      const sibling = { id: 14, title: 'Sibling' };
+      const group = { id: 11, title: 'Group', children: [page, sibling] };
+      const root = { id: 10, title: 'Root', children: [group] };
+      mocks.selectedRoutes = [root, group, page, leaf, ...(hasSibling ? [sibling] : [])];
+      mocks.desktopRoutesList.mockResolvedValue({ data: { data: [root] } });
+      renderMenuPermissions();
+      for (const name of ['Root', 'Group', 'Page']) {
+        const row = (await screen.findByText(name)).closest('tr');
+        fireEvent.click(within(row).getByRole('button', { name: 'Expand row' }));
+      }
+      fireEvent.click(within(screen.getByRole('row', { name: 'Leaf', exact: true })).getByRole('checkbox'));
+      await waitFor(() => {
+        expect(mocks.rolesDesktopRoutesRemove).toHaveBeenCalledWith({
+          values: hasSibling ? [13, 12] : [13, 12, 11, 10],
+        });
+      });
+      for (const name of ['Leaf', 'Page']) {
+        expect(within(screen.getByText(name).closest('tr')).getByRole('checkbox')).not.toBeChecked();
+      }
+      for (const name of ['Root', 'Group', 'Sibling']) {
+        const checkbox = within(screen.getByText(name).closest('tr')).getByRole('checkbox');
+        if (hasSibling) {
+          expect(checkbox).toBeChecked();
+        } else {
+          expect(checkbox).not.toBeChecked();
+        }
+      }
+    },
+  );
+
   it('does not add already accessible descendants again when checking their parent', async () => {
     const child = { id: 11, title: 'Child' };
     mocks.selectedRoutes = [child];


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

配置角色的桌面端路由权限时，勾选深层菜单只会带上直接上级，更高层菜单仍未选中，导致菜单入口权限不完整。

### Description

勾选深层菜单时自动选中全部上级，同时避免重复添加已有权限。保留原有两层菜单勾选行为，不影响未选中的同级菜单。

新增两条测试，修复前均按预期失败，修复后全部四条测试通过；触及文件的 lint 通过。浏览器已验证深层及两层勾选、保存成功和重新进入后的状态，测试时修改的角色权限已还原。当前账号无法切换到目标角色，未直接验证该角色登录后的页面可见性。

建议回归：勾选三级及以上菜单，确认全部上级自动选中且重新进入后保持一致；选择已有部分子菜单权限的父菜单，确认保存正常。

### Showcase

三级示例：人工测试 → 防白屏 → 未命名。勾选“未命名”后，三个层级均选中。

### Changelog

| Language | Changelog |
| --- | --- |
| 🇺🇸 English | Fix role permissions so selecting a deeply nested menu also selects all parent menus |
| 🇨🇳 Chinese | 修复角色权限中勾选深层菜单时未自动选中全部上级菜单的问题 |

### Docs

| Language | Link |
| --- | --- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | 无需更新 |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
