### PR TITLE
fix(client-v2): avoid settings page reload

### DIFF
--- a/packages/core/client-v2/src/flow/admin-shell/admin-layout/__tests__/TopbarActionsBar.test.tsx
+++ b/packages/core/client-v2/src/flow/admin-shell/admin-layout/__tests__/TopbarActionsBar.test.tsx
@@ -9,7 +9,7 @@
 
 import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter, useLocation } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const { allowMock, appMock, flowModelRendererSpy } = vi.hoisted(() => {
@@ -270,28 +270,47 @@ describe('TopbarActionsBar helpers', () => {
     expect(link).not.toHaveAttribute('target', '_blank');
   });
 
-  it('should keep sub-app admin settings in the current window inside sub-app admin runtime', () => {
-    const items = getTopbarPluginSettingsItems({
-      canManagePlugins: false,
-      t: (key) => key,
-      settings: [
-        {
-          key: 'routes',
-          name: 'routes',
-          title: 'Routes',
-          path: '/admin/settings/routes',
-          icon: null,
-          componentLoader: async () => null,
-        },
-      ] as any,
-    });
+  it.each(['/nocobase/v', '/v', '/nocobase/v/apps/jhb20'])(
+    'should navigate sub-app settings without document navigation with basename %s',
+    (basename) => {
+      appMock.current.router.getBasename = () => basename;
+      const items = getTopbarPluginSettingsItems({
+        canManagePlugins: false,
+        t: (key) => key,
+        settings: [
+          {
+            key: 'ai',
+            name: 'ai',
+            title: 'AI employees',
+            path: '/admin/settings/ai',
+            icon: null,
+            componentLoader: async () => null,
+          },
+        ],
+      });
+      const item = items[0];
+      if (!item || !('label' in item)) {
+        throw new Error('Expected settings menu item');
+      }
+      const appBase = basename.endsWith('/apps/jhb20') ? basename : `${basename}/apps/jhb20`;
+      const targetHref = `${appBase}/admin/settings/ai`;
+      const LocationDisplay = () => <output aria-label="Current route">{useLocation().pathname}</output>;
+      render(
+        <MemoryRouter basename={basename} initialEntries={[`${appBase}/admin/a3pq1t1773a`]}>
+          {item.label}
+          <LocationDisplay />
+        </MemoryRouter>,
+      );
 
-    renderSettingsLabel((items as any[])[0].label, '/apps/a_9xlild35jir/admin/settings/routes');
-
-    const link = screen.getByRole('link', { name: 'Routes' });
-    expect(link).toHaveAttribute('href', '/nocobase/v/apps/a_9xlild35jir/admin/settings/routes');
-    expect(link).not.toHaveAttribute('target', '_blank');
-  });
+      const link = screen.getByRole('link', { name: 'AI employees' });
+      expect(link).toHaveAttribute('href', targetHref);
+      expect(link).not.toHaveAttribute('target', '_blank');
+      const click = new MouseEvent('click', { bubbles: true, cancelable: true, button: 0 });
+      fireEvent(link, click);
+      expect(click.defaultPrevented).toBe(true);
+      expect(screen.getByLabelText('Current route')).toHaveTextContent(targetHref.slice(basename.length));
+    },
+  );
 
   it('should not treat admin-like paths as admin runtime', () => {
     const items = getTopbarPluginSettingsItems({

--- a/packages/core/client-v2/src/flow/models/topbar/TopbarActionModel.tsx
+++ b/packages/core/client-v2/src/flow/models/topbar/TopbarActionModel.tsx
@@ -201,12 +201,12 @@ function TopbarInternalSettingsLabel(props: { title: React.ReactNode; path?: str
       adminRoutePath: getTopbarAdminRoutePath(app),
     });
 
+    if (!shouldOpenInNewWindow) {
+      return <Link to={stripTopbarRouterBasePath(targetPathInCurrentApp, basename)}>{props.title}</Link>;
+    }
+
     return (
-      <a
-        href={href}
-        target={shouldOpenInNewWindow ? '_blank' : undefined}
-        rel={shouldOpenInNewWindow ? 'noopener noreferrer' : undefined}
-      >
+      <a href={href} target="_blank" rel="noopener noreferrer">
         {props.title}
       </a>
     );


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

从区块页面打开顶部系统菜单并进入“AI 员工”等功能时，整个页面会重新加载，出现短暂白屏。

### Description

修复进入配置页面时整页刷新的问题。需要在新窗口打开的入口仍保持原有行为。

补充三种访问路径前缀的导航测试，修复前均失败，修复后通过；相关前端测试共 42 个通过，lint 通过。浏览器已验证进入 AI 员工及返回区块页时不重新加载文档，顶部栏保持显示。三份独立代码审查均未发现需修改的问题。

建议回归主应用和子应用从区块页进入系统功能、浏览器返回，以及需要新窗口打开的入口；重点关注不同部署路径下的跳转地址。

### Showcase

已通过浏览器验证 AI 员工列表正常显示，并可返回原区块页面。

### Changelog

| Language | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix full-page reloads when opening settings pages |
| 🇨🇳 Chinese | 修复进入配置页面时整页刷新的问题 |

### Docs

无需更新文档

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
