### PR TITLE
fix(plugin-file-manager): prevent caching signed URL redirects

### DIFF
--- a/packages/plugins/@nocobase/plugin-file-manager/src/server/__tests__/server.test.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/server/__tests__/server.test.ts
@@ -867,6 +867,7 @@ describe('file manager > server', () => {
 
         expect(response.status).toBe(302);
         expect(response.headers.location).toBe(storageUrl);
+        expect(response.headers['cache-control']).toBe('private, no-store');
       });
 
       it('preserves the sub-application when redirecting to local storage', async () => {
@@ -1018,6 +1019,7 @@ describe('file manager > server', () => {
         expect(file.toJSON()).toMatchObject({ local: false });
         expect(getResponse.body.data.local).toBe(false);
         expect(response.status).toBe(302);
+        expect(response.headers['cache-control']).toBe('private, no-store');
         expect(location.searchParams.get('response-content-disposition')).toContain('attachment');
         expect(location.searchParams.get('X-Amz-Signature')).toBeTruthy();
       });
@@ -1033,6 +1035,7 @@ describe('file manager > server', () => {
 
         expect(response.status).toBe(302);
         expect(response.headers.location).toBe(await plugin.getFileURL(body.data));
+        expect(response.headers['cache-control']).toBe('private, no-store');
         expect(response.text || '').toBe('');
       });
 

--- a/packages/plugins/@nocobase/plugin-file-manager/src/server/actions/get-file.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/server/actions/get-file.ts
@@ -142,6 +142,7 @@ export async function getFile(ctx: Context, next: Next) {
       download,
     })) || (await plugin.getFileURL(file, preview, { download }));
   const finalUrl = preserveSubAppInLocalURL(storageUrl, ctx.state.fileAccess?.appName);
+  ctx.set('Cache-Control', 'private, no-store');
   ctx.status = 302;
   ctx.redirect(finalUrl);
   await next();


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Permanent file URLs redirect to storage URLs. For private S3-compatible storage, the redirect target is a short-lived signed URL. Because the redirect response did not specify a cache policy, clients or intermediate caches could reuse a cached `Location` after its signature expired.

### Description

- Add `Cache-Control: private, no-store` to the common file redirect response so every permanent file URL is resolved again on access.
- Cover regular GET redirects, signed S3 download redirects, and HEAD redirects with regression assertions.

Risk is low because the change only disables caching of the redirect response. Storage responses and their cache policies are unchanged.

Testing:

- `yarn test packages/plugins/@nocobase/plugin-file-manager/src/server/__tests__/server.test.ts --run`
- `yarn eslint --fix packages/plugins/@nocobase/plugin-file-manager/src/server/actions/get-file.ts packages/plugins/@nocobase/plugin-file-manager/src/server/__tests__/server.test.ts`

### Related issues

N/A

### Showcase

N/A (server-side response header change)

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Prevent file redirects from reusing expired signed storage URLs. |
| 🇨🇳 Chinese | 防止文件重定向复用已过期的存储签名 URL。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
