### PR TITLE
fix(client-v2): disable inverse relationship type editing

### DIFF
--- a/packages/core/client-v2/src/collection-manager/__tests__/field-configure.test.ts
+++ b/packages/core/client-v2/src/collection-manager/__tests__/field-configure.test.ts
@@ -1,0 +1,52 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { getCoreFieldConfigureState, reverseFieldConfigureItems } from '../field-configure';
+
+describe('inverse relationship configuration', () => {
+  it.each(['hasOne', 'hasMany', 'belongsTo', 'belongsToMany'])(
+    'keeps the %s inverse relationship type disabled when creating or editing a field',
+    (type) => {
+      for (const createOnly of [true, false]) {
+        for (const showReverseFieldConfig of [true, false]) {
+          const values = {
+            autoCreateReverseField: true,
+            reverseField: { type, ...(createOnly ? {} : { key: 'existing-reverse-field' }) },
+          };
+
+          expect(
+            getCoreFieldConfigureState('reverseField.type', values, { createOnly, showReverseFieldConfig }),
+          ).toEqual({
+            disabled: true,
+            hidden: !showReverseFieldConfig,
+          });
+        }
+      }
+    },
+  );
+
+  it.each(['reverseField.name', 'reverseField.uiSchema.title'])(
+    'allows editing %s only when the inverse configuration is visible',
+    (name) => {
+      for (const showReverseFieldConfig of [true, false]) {
+        expect(getCoreFieldConfigureState(name, {}, { showReverseFieldConfig })).toEqual({
+          disabled: !showReverseFieldConfig,
+          hidden: !showReverseFieldConfig,
+        });
+      }
+    },
+  );
+
+  it('also disables the inverse relationship type in explicit configure items', () => {
+    const item = reverseFieldConfigureItems().find(({ name }) => name === 'reverseField.type');
+
+    expect(item?.disabled).toBe(true);
+  });
+});

--- a/packages/core/client-v2/src/collection-manager/field-configure.ts
+++ b/packages/core/client-v2/src/collection-manager/field-configure.ts
@@ -271,7 +271,7 @@ export function getCoreFieldConfigureState(
 
   if (name.startsWith('reverseField.')) {
     return {
-      disabled: !context.showReverseFieldConfig,
+      disabled: name === 'reverseField.type' || !context.showReverseFieldConfig,
       hidden: !context.showReverseFieldConfig,
     };
   }
@@ -514,7 +514,7 @@ export function reverseFieldConfigureItems(): FieldConfigureItem[] {
         { label: "{{t('BelongsToMany')}}", value: 'belongsToMany' },
       ],
       hidden: ({ context, values }) => !context.showReverseFieldConfig && !get(values, 'autoCreateReverseField'),
-      disabled: ({ context }) => !context.showReverseFieldConfig,
+      disabled: true,
     },
     {
       name: 'reverseField.uiSchema.title',


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
In v2 field configuration, enabling inverse field creation incorrectly makes the inverse relationship type editable. Its type is determined by the selected relationship interface and should remain disabled.

### Description
- Keep reverseField.type disabled in the core runtime state instead of overriding its existing disabled schema setting.
- Apply the same restriction to explicit inverse-field configure items.
- Preserve visibility behavior and editing of the inverse field name and display name.
- Add seven regression cases covering all four relationship types, create/edit states, visibility, and the explicit configure-item helper.

Risk assessment: low. Production changes are limited to two disabled-state expressions in client-v2. No v1, API, authorization, database, migration, or stored-value changes. This is a UI restriction, not new server-side validation. No setup or deployment automation is introduced; repeated rendering applies the same state without data mutations.

Verification performed locally:
- `yarn test packages/core/client-v2/src/collection-manager/__tests__/field-configure.test.ts --run --reporter=verbose` — 7 passed.
- `yarn test packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/__tests__/FieldForm.test.tsx --run --reporter=verbose` — 5 passed.
- `yarn test packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/__tests__/FieldForm.test.ts --run --reporter=verbose` — 8 passed.
- `yarn eslint --fix packages/core/client-v2/src/collection-manager/field-configure.ts packages/core/client-v2/src/collection-manager/__tests__/field-configure.test.ts` — passed.
- `git diff --check` and staged diff check — passed; commit hooks also passed.

Known verification limits: no browser/manual verification, full build, or standalone type check performed. Remote CI is not yet verified. Existing test output includes Node deprecation, antd-mobile environment, and circular-reference warnings without failures.

Suggested manual check: create/edit a v2 relationship field, enable inverse field creation, confirm the preselected inverse type cannot be changed or cleared, and confirm inverse field names remain editable.

### Related issues
Task 6289.

### Showcase
Not provided; the inverse relationship type selector remains disabled.

### Changelog

| Language | Changelog |
| ---------- | --------- |
| English | Fixed the inverse relationship type being editable in v2 field configuration. |
| Chinese | 修复 v2 字段配置中反向关系类型可被修改的问题。 |

### Docs
Not needed; restores intended behavior without adding a feature.

### Checklists
- [ ] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary