### PR TITLE
fix(v2 form): resolve nested associations from dropdown values

### DIFF
--- a/packages/core/client-v2/src/flow/models/blocks/form/FormBlockModel.tsx
+++ b/packages/core/client-v2/src/flow/models/blocks/form/FormBlockModel.tsx
@@ -399,20 +399,35 @@ export class FormBlockModel<
           if (Array.isArray(topValue) && topValue.length === 0) return false;
 
           // 本地优先：支持对多关系的 dot 聚合路径（例如 assignees.name）。
-          // lodash.get 对数组聚合路径会返回 undefined（如 _.get({ assignees:[{name:'A'}] }, 'assignees.name')），
-          // 因而这里先用 getValuesByPath 做一次前端可解析性检查，命中则直接前端解析。
+          // 关联字段只有在本地值为对象、对象数组或空值时才算完整；标量外键仍需由服务端补全关联记录。
           const formValuesSnapshot = runtime.getFormValuesSnapshot();
+          let shouldResolveAssociationValueOnServer = false;
           if (formValuesSnapshot && typeof formValuesSnapshot === 'object') {
-            const localResolved = getValuesByPath(formValuesSnapshot as Record<string, any>, subPath);
+            const localResolved = getValuesByPath(formValuesSnapshot as Record<string, unknown>, subPath);
             if (typeof localResolved !== 'undefined') {
-              return false;
+              const fieldPath = subPath
+                .replace(/\[\d+\]/g, '')
+                .split('.')
+                .filter((segment) => !/^\d+$/.test(segment))
+                .join('.');
+              const resolvedField = this.collection?.getFieldByPath?.(fieldPath);
+              const isAssociationValueLoaded =
+                localResolved === null ||
+                (Array.isArray(localResolved)
+                  ? localResolved.length === 0 ||
+                    localResolved.every((value) => value !== null && typeof value === 'object')
+                  : typeof localResolved === 'object');
+              if (!resolvedField?.isAssociationField?.() || isAssociationValueLoaded) {
+                return false;
+              }
+              shouldResolveAssociationValueOnServer = true;
             }
           }
 
           // 已配置字段：仅关联字段的子路径按需服务端补全（保持现有语义）
           const assocResolver = createAssociationSubpathResolver(
             () => this.collection,
-            () => runtime.getFormValuesSnapshot(),
+            shouldResolveAssociationValueOnServer ? undefined : () => runtime.getFormValuesSnapshot(),
           );
           return assocResolver(subPath);
         }

--- a/packages/core/client-v2/src/flow/models/blocks/form/FormBlockModel.tsx
+++ b/packages/core/client-v2/src/flow/models/blocks/form/FormBlockModel.tsx
@@ -399,7 +399,7 @@ export class FormBlockModel<
           if (Array.isArray(topValue) && topValue.length === 0) return false;
 
           // 本地优先：支持对多关系的 dot 聚合路径（例如 assignees.name）。
-          // 关联字段只有在本地值为对象、对象数组或空值时才算完整；标量外键仍需由服务端补全关联记录。
+          // 关联字段只有在本地值包含目标标题字段时才算完整；标量外键或仅含主键的轻量对象仍需服务端补全。
           const formValuesSnapshot = runtime.getFormValuesSnapshot();
           let shouldResolveAssociationValueOnServer = false;
           if (formValuesSnapshot && typeof formValuesSnapshot === 'object') {
@@ -411,12 +411,18 @@ export class FormBlockModel<
                 .filter((segment) => !/^\d+$/.test(segment))
                 .join('.');
               const resolvedField = this.collection?.getFieldByPath?.(fieldPath);
+              const titleFieldName = resolvedField?.targetCollectionTitleFieldName;
+              const isLoadedAssociationRecord = (value: unknown) => {
+                if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+                if (!titleFieldName) return true;
+                return typeof (value as Record<string, unknown>)[titleFieldName] !== 'undefined';
+              };
               const isAssociationValueLoaded =
                 localResolved === null ||
                 (Array.isArray(localResolved)
                   ? localResolved.length === 0 ||
-                    localResolved.every((value) => value !== null && typeof value === 'object')
-                  : typeof localResolved === 'object');
+                    localResolved.every((value) => value === null || isLoadedAssociationRecord(value))
+                  : isLoadedAssociationRecord(localResolved));
               if (!resolvedField?.isAssociationField?.() || isAssociationValueLoaded) {
                 return false;
               }

--- a/packages/core/client-v2/src/flow/models/blocks/form/__tests__/FormBlockModel.test.tsx
+++ b/packages/core/client-v2/src/flow/models/blocks/form/__tests__/FormBlockModel.test.tsx
@@ -549,6 +549,109 @@ describe('FormBlockModel (form/formValues injection & server resolve anchors)', 
     expect(api.request).toHaveBeenCalledTimes(1);
   });
 
+  it('resolves a configured nested association from the server when the local value is only its key', async () => {
+    const model = await setupFormModel();
+    const api = {
+      request: vi.fn(async (config: any) => {
+        const batch = config?.data?.values?.batch || [];
+        const item = batch[0] || {};
+        expect(item.template).toEqual({ level: '{{ ctx.formValues.customer.level }}' });
+        expect(Object.keys(item.contextParams || {})).toEqual(['formValues.customer']);
+        expect(item.contextParams['formValues.customer']).toMatchObject({
+          collection: 'customers',
+          filterByTk: 9,
+        });
+        return {
+          data: {
+            data: {
+              results: [{ id: item.id, data: { level: { id: 'level-1', name: 'Level 1' } } }],
+            },
+          },
+        } as any;
+      }),
+    } as any;
+    (model.flowEngine.context as any).defineProperty('api', { value: api });
+
+    function HookCaller() {
+      model.useHooksBeforeRender();
+      return null;
+    }
+    render(React.createElement(HookCaller));
+
+    const mem: Record<string, any> = {};
+    const fakeForm = {
+      setFieldsValue: (values: Record<string, any>) => Object.assign(mem, values),
+      getFieldsValue: () => ({ ...mem }),
+      getFieldValue: (namePath: any) => getByPath(mem, namePath),
+      setFieldValue: (key: string, value: any) => (mem[key] = value),
+    };
+    (model.context as any).defineProperty('form', { value: fakeForm });
+    fakeForm.setFieldsValue({ customer: { id: 9, level: 'level-1' } });
+    mockFormGridEnabledFields(model, ['customer']);
+
+    const output = await (model.context as any).resolveJsonTemplate({
+      level: '{{ ctx.formValues.customer.level }}',
+    });
+
+    expect(api.request).toHaveBeenCalledTimes(1);
+    expect(output).toEqual({ level: { id: 'level-1', name: 'Level 1' } });
+  });
+
+  it('uses a configured nested association locally when its record is already loaded', async () => {
+    const model = await setupFormModel();
+    const api = { request: vi.fn(async () => ({ data: {} }) as any) } as any;
+    (model.flowEngine.context as any).defineProperty('api', { value: api });
+
+    function HookCaller() {
+      model.useHooksBeforeRender();
+      return null;
+    }
+    render(React.createElement(HookCaller));
+
+    const mem: Record<string, any> = {};
+    const fakeForm = {
+      setFieldsValue: (values: Record<string, any>) => Object.assign(mem, values),
+      getFieldsValue: () => ({ ...mem }),
+      getFieldValue: (namePath: any) => getByPath(mem, namePath),
+      setFieldValue: (key: string, value: any) => (mem[key] = value),
+    };
+    (model.context as any).defineProperty('form', { value: fakeForm });
+    const level = { id: 'level-1', name: 'Level 1' };
+    fakeForm.setFieldsValue({ customer: { id: 9, level } });
+    mockFormGridEnabledFields(model, ['customer']);
+
+    const output = await (model.context as any).resolveJsonTemplate({
+      level: '{{ ctx.formValues.customer.level }}',
+    });
+
+    expect(output).toEqual({ level });
+    expect(api.request).not.toHaveBeenCalled();
+  });
+
+  it('keeps indexed paths local when the nested association record is already loaded', async () => {
+    const model = await setupFormModel();
+
+    function HookCaller() {
+      model.useHooksBeforeRender();
+      return null;
+    }
+    render(React.createElement(HookCaller));
+
+    const mem: Record<string, any> = {};
+    const fakeForm = {
+      setFieldsValue: (values: Record<string, any>) => Object.assign(mem, values),
+      getFieldsValue: () => ({ ...mem }),
+      getFieldValue: (namePath: any) => getByPath(mem, namePath),
+      setFieldValue: (key: string, value: any) => (mem[key] = value),
+    };
+    (model.context as any).defineProperty('form', { value: fakeForm });
+    fakeForm.setFieldsValue({ assignees: [{ id: 3, org: { id: 1, name: 'Org 1' } }] });
+    mockFormGridEnabledFields(model, ['assignees']);
+
+    const options = (model.context as any).getPropertyOptions('formValues');
+    expect(options.resolveOnServer('assignees[0].org.name')).toBe(false);
+  });
+
   it('configured toMany dot aggregation path uses local value and skips server', async () => {
     const model = await setupFormModel();
 

--- a/packages/core/client-v2/src/flow/models/blocks/form/__tests__/FormBlockModel.test.tsx
+++ b/packages/core/client-v2/src/flow/models/blocks/form/__tests__/FormBlockModel.test.tsx
@@ -77,6 +77,7 @@ async function setupFormModel() {
   ds.addCollection({
     name: 'levels',
     filterTargetKey: 'id',
+    titleField: 'name',
     fields: [
       { name: 'id', type: 'integer', interface: 'number' },
       { name: 'name', type: 'string', interface: 'text' },
@@ -587,6 +588,47 @@ describe('FormBlockModel (form/formValues injection & server resolve anchors)', 
     };
     (model.context as any).defineProperty('form', { value: fakeForm });
     fakeForm.setFieldsValue({ customer: { id: 9, level: 'level-1' } });
+    mockFormGridEnabledFields(model, ['customer']);
+
+    const output = await (model.context as any).resolveJsonTemplate({
+      level: '{{ ctx.formValues.customer.level }}',
+    });
+
+    expect(api.request).toHaveBeenCalledTimes(1);
+    expect(output).toEqual({ level: { id: 'level-1', name: 'Level 1' } });
+  });
+
+  it('resolves a configured nested association when its local record does not include the title field', async () => {
+    const model = await setupFormModel();
+    const api = {
+      request: vi.fn(async (config: any) => {
+        const item = config?.data?.values?.batch?.[0] || {};
+        return {
+          data: {
+            data: {
+              results: [{ id: item.id, data: { level: { id: 'level-1', name: 'Level 1' } } }],
+            },
+          },
+        } as any;
+      }),
+    } as any;
+    (model.flowEngine.context as any).defineProperty('api', { value: api });
+
+    function HookCaller() {
+      model.useHooksBeforeRender();
+      return null;
+    }
+    render(React.createElement(HookCaller));
+
+    const mem: Record<string, any> = {};
+    const fakeForm = {
+      setFieldsValue: (values: Record<string, any>) => Object.assign(mem, values),
+      getFieldsValue: () => ({ ...mem }),
+      getFieldValue: (namePath: any) => getByPath(mem, namePath),
+      setFieldValue: (key: string, value: any) => (mem[key] = value),
+    };
+    (model.context as any).defineProperty('form', { value: fakeForm });
+    fakeForm.setFieldsValue({ customer: { id: 9, level: { id: 'level-1' } } });
     mockFormGridEnabledFields(model, ['customer']);
 
     const output = await (model.context as any).resolveJsonTemplate({

--- a/packages/plugins/@nocobase/plugin-flow-engine/src/server/__tests__/variables.record-slot-policy.test.ts
+++ b/packages/plugins/@nocobase/plugin-flow-engine/src/server/__tests__/variables.record-slot-policy.test.ts
@@ -135,6 +135,62 @@ describe('record slot policy compiler', () => {
     expect(getPolicy(contract.recordSlots, '{{ ctx.formValues.permissions.name }}')?.slot).toEqual(['permissions']);
   });
 
+  it('anchors a Form association display item to its parent association record', async () => {
+    const app = createApp();
+    installBuiltIns(app);
+    const staff = { name: 'staff' };
+    const roles = {
+      name: 'roles',
+      getField: (name: string) =>
+        name === 'users' ? { isRelationField: () => true, targetCollection: () => staff } : undefined,
+    };
+    const users = {
+      name: 'users',
+      getField: (name: string) =>
+        name === 'roles' ? { isRelationField: () => true, targetCollection: () => roles } : undefined,
+    };
+    const expression = '{{ ctx.formValues.roles.users }}';
+    const associationItem = {
+      use: 'FormAssociationItemModel',
+      stepParams: {
+        fieldSettings: {
+          init: {
+            associationPathName: 'roles',
+            collectionName: 'users',
+            dataSourceKey: 'main',
+            fieldPath: 'roles.users',
+          },
+        },
+      },
+      props: expression,
+    };
+    const form = {
+      use: 'CreateFormModel',
+      stepParams: { resourceSettings: { init: { collectionName: 'users', dataSourceKey: 'main' } } },
+      subModels: {
+        grid: {
+          use: 'FormGridModel',
+          subModels: {
+            items: [
+              { use: 'FormItemModel', stepParams: { fieldSettings: { init: { fieldPath: 'roles' } } } },
+              associationItem,
+            ],
+          },
+        },
+      },
+    };
+    const contract = await compile(app, associationItem, {
+      getCollection: (_dataSourceKey, collection) => {
+        if (collection === 'users') return users;
+        if (collection === 'roles') return roles;
+        return staff;
+      },
+      loadAncestors: async () => [form.subModels.grid, form],
+    });
+
+    expect(getPolicy(contract.recordSlots, expression)?.slot).toEqual(['roles']);
+  });
+
   it('derives item and parent item slots from association field provenance', async () => {
     const app = createApp();
     installBuiltIns(app);

--- a/packages/plugins/@nocobase/plugin-flow-engine/src/server/__tests__/variables.resolve.provider-tree.test.ts
+++ b/packages/plugins/@nocobase/plugin-flow-engine/src/server/__tests__/variables.resolve.provider-tree.test.ts
@@ -137,6 +137,63 @@ describe('variables:resolve persisted Form provider tree', () => {
     }
   });
 
+  it('resolves an exact nested association value from its parent association record', async () => {
+    const uid = 'provider-tree-exact-association';
+    const leafUid = `${uid}-users-field`;
+    const template = { users: '{{ ctx.formValues.roles.users }}' };
+    await insertFlowModel({
+      uid,
+      use: 'CustomFormWithRecordProvider',
+      stepParams: { resourceSettings: { init: { dataSourceKey: 'main', collectionName: 'users' } } },
+      subModels: {
+        grid: {
+          uid: `${uid}-grid`,
+          use: 'CustomFormGrid',
+          subModels: {
+            items: [
+              {
+                uid: `${uid}-roles-field`,
+                use: 'CustomFormField',
+                stepParams: { fieldSettings: { init: { fieldPath: 'roles' } } },
+              },
+              {
+                uid: leafUid,
+                use: 'FormAssociationItemModel',
+                props: template,
+                stepParams: {
+                  fieldSettings: {
+                    init: {
+                      associationPathName: 'roles',
+                      collectionName: 'users',
+                      dataSourceKey: 'main',
+                      fieldPath: 'roles.users',
+                    },
+                  },
+                },
+              },
+            ],
+          },
+        },
+      },
+    });
+    const rolesFindOne = vi.spyOn(app.db.getRepository('roles'), 'findOne');
+
+    try {
+      const response = await execResolve({
+        contextParams: {
+          'formValues.roles': { collection: 'roles', filterByTk: 'root' },
+        },
+        rd: session.rd(leafUid),
+        template,
+      });
+
+      expect(response.users).toEqual(expect.arrayContaining([expect.objectContaining({ id: expect.any(Number) })]));
+      expect(rolesFindOne).toHaveBeenCalledTimes(1);
+    } finally {
+      rolesFindOne.mockRestore();
+    }
+  });
+
   it('resolves root, parent, and child exact slots through the batch action without post-prefetch queries', async () => {
     const uid = 'provider-tree-batch';
     const template = {

--- a/packages/plugins/@nocobase/plugin-flow-engine/src/server/variables/form-item-record-slot-resolvers.ts
+++ b/packages/plugins/@nocobase/plugin-flow-engine/src/server/variables/form-item-record-slot-resolvers.ts
@@ -17,6 +17,7 @@ import type {
 type FlowModelOptions = Readonly<{
   stepParams?: unknown;
   subModels?: unknown;
+  use?: unknown;
 }>;
 
 type ResourceTarget = Readonly<{
@@ -212,6 +213,7 @@ function getConfiguredAssociationSlots(
   source: CollectionRef,
   items: readonly FlowModelOptions[],
 ) {
+  const exactAnchors = new Map<string, readonly string[]>();
   const slots = new Map<string, readonly string[]>();
   const fieldPaths: string[][] = [];
   for (const item of items) {
@@ -226,8 +228,11 @@ function getConfiguredAssociationSlots(
       slots.set(prefix.join('.'), [...prefix]);
       current = edge.target;
     }
+    if (item.use === 'FormAssociationItemModel' && prefix.length > 1 && prefix.length === fieldPath.length) {
+      exactAnchors.set(prefix.join('.'), prefix.slice(0, -1));
+    }
   }
-  return { fieldPaths, slots: [...slots.values()] };
+  return { exactAnchors, fieldPaths, slots: [...slots.values()] };
 }
 
 async function resolveFormValues(input: RecordSlotResolverInput): Promise<RecordSlotResolverResult> {
@@ -242,7 +247,10 @@ async function resolveFormValues(input: RecordSlotResolverInput): Promise<Record
   for (const slot of configuredSlots.slots) {
     if (pathStartsWith(runtimePath, slot) && (!configured || slot.length > configured.length)) configured = slot;
   }
-  if (configured) return resolved(configured);
+  if (configured) {
+    const exactAnchor = configuredSlots.exactAnchors.get(runtimePath.join('.'));
+    return resolved(exactAnchor || configured);
+  }
 
   const top = runtimePath[0];
   if (typeof top !== 'string') return runtimePath.length ? { status: 'deny' } : resolved([]);


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

In V2 forms, a nested association display field rendered blank when its parent association used dropdown selection. Popup selection worked because it supplied a fully populated record, while dropdown selection could leave the nested relation as a scalar key or partial object.

### Description

- Hydrate scalar and partial nested association values through `variables:resolve` when the local form value does not contain the target title field.
- Fix persisted Form record-slot authorization for `FormAssociationItemModel`: an exact nested relation such as `formValues.org_m2o.staff_oho` is now resolved from the parent association record anchor `formValues.org_m2o`.
- Keep loaded association records, empty values, to-many aggregation, indexed paths, other Form item models, and deeper explicitly anchored relation paths unchanged.
- Add client resolution coverage, a focused record-slot policy test, and an end-to-end server resolver regression case.

Current behavior and boundaries:

- The change only affects configured V2 Form association display fields during variable resolution.
- No API contract, database schema, migration, ACL widening, or V1 runtime behavior changes are included.
- The server-side fallback is restricted to exact relation paths owned by `FormAssociationItemModel`; other persisted record-slot policies retain their existing behavior.

Runtime evidence:

- On the PR preview, selecting organization `1` sent a valid `variables:resolve` batch with templates `{{ctx.formValues.org_m2o.staff_oho}}` and `{{ctx.formValues.org_m2o.staff_m2o}}` plus the `formValues.org_m2o` record descriptor.
- Before this fix, the endpoint returned both templates unchanged even though direct read-only association queries returned populated `staff_oho` and `staff_m2o` records. This isolated the issue to record-slot binding rather than dropdown data or rendering refresh.
- After commit `36cddfa2256dc97519c09949f36e268a75c4b2d2` was deployed, repeating the same dropdown selection resolved the two association records and rendered their title values `122` and `25` on the form.

Verification:

- `PATH=/Users/tangxiaoai/.nvm/versions/node/v22.22.2/bin:$PATH yarn test packages/plugins/@nocobase/plugin-flow-engine/src/server/__tests__/variables.record-slot-policy.test.ts --run --reporter=verbose` — 13 tests passed locally.
- `PATH=/Users/tangxiaoai/.nvm/versions/node/v22.22.2/bin:$PATH yarn test packages/core/client-v2/src/flow/models/blocks/form/__tests__/FormBlockModel.test.tsx --run --reporter=verbose` — 29 tests passed locally.
- `PATH=/Users/tangxiaoai/.nvm/versions/node/v22.22.2/bin:$PATH yarn eslint --fix packages/plugins/@nocobase/plugin-flow-engine/src/server/variables/form-item-record-slot-resolvers.ts packages/plugins/@nocobase/plugin-flow-engine/src/server/__tests__/variables.record-slot-policy.test.ts packages/plugins/@nocobase/plugin-flow-engine/src/server/__tests__/variables.resolve.provider-tree.test.ts` — passed.
- `git diff --check` and `git diff --cached --check` — passed.
- PR preview smoke test — passed against `https://pr-10477.v2.test.nocobase.com`; selecting organization `1` rendered `staff_oho: 122` and `staff_m2o: 25`.
- Remote frontend CI — all four test shards passed after rerunning the dependency-installation infrastructure failure.
- The focused integration test file `variables.resolve.provider-tree.test.ts` could not start locally because this checkout does not have the optional `sqlite3` package; the smaller pure policy test covers the same slot decision. Remote backend CI is expected to run the integration case.

### Risks and review focus

- Risk is low: the functional server change is a scoped record-slot remap for one V2 model and one exact nested-relation shape.
- Review the `FormAssociationItemModel` type guard and parent-slot selection in `form-item-record-slot-resolvers.ts`.
- The PR preview has been rechecked after deployment; review focus remains the narrow parent-slot mapping and its integration coverage.

### Related issues

Task 6281

### Showcase

Manual verification target: configure a V2 relation field as dropdown select, display nested relation fields, and confirm their titles render after changing the dropdown value just as they do after popup selection.

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix nested association fields rendering blank in V2 forms when the parent relation uses dropdown selection. |
| 🇨🇳 Chinese | 修复 V2 表单父级关系使用下拉选择时，嵌套关系字段显示为空的问题。 |

### Docs

| Language   | Link |
| ---------- | ---- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | 不需要 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
