### PR TITLE
fix(client-v2): fix mobile filter collapse

### DIFF
--- a/packages/core/client-v2/src/flow/models/base/GridModel.tsx
+++ b/packages/core/client-v2/src/flow/models/base/GridModel.tsx
@@ -922,7 +922,6 @@ export class GridModel<T extends { subModels: { items: FlowModel[] } } = Default
     const baseLayout = this.context.isMobileLayout
       ? normalizeGridLayout({
           rows: transformRowsToSingleColumn(projectLayoutToLegacyRows(rawLayout).rows),
-          itemUids: this.getItemUids(),
         })
       : rawLayout;
     const baseProjection = projectLayoutToLegacyRows(baseLayout);

--- a/packages/core/client-v2/src/flow/models/blocks/filter-form/__tests__/FilterFormGridModel.toggleFormFieldsCollapse.test.ts
+++ b/packages/core/client-v2/src/flow/models/blocks/filter-form/__tests__/FilterFormGridModel.toggleFormFieldsCollapse.test.ts
@@ -21,6 +21,35 @@ describe('FilterFormGridModel.toggleFormFieldsCollapse', () => {
     engine.registerModels({ FilterFormGridModel });
   });
 
+  it.each([false, true])('preserves collapsed fields in mobile layout with settings enabled: %s', (settingsEnabled) => {
+    engine.flowSettings[settingsEnabled ? 'enable' : 'disable']();
+    const rows = {
+      first: [['field-1']],
+      second: [['field-2']],
+      third: [['field-3']],
+    };
+    const model = engine.createModel<FilterFormGridModel>({
+      uid: 'mobile-filter-grid',
+      use: 'FilterFormGridModel',
+      props: { rows },
+      subModels: {
+        items: ['field-1', 'field-2', 'field-3'].map((uid) => ({ use: 'FlowModel', uid })),
+      },
+    });
+    model.context.defineProperty('isMobileLayout', { value: true });
+    model.setStepParams(GRID_FLOW_KEY, GRID_STEP, { rows });
+    type VisibleLayoutReader = { getVisibleLayout(): { rows: Record<string, string[][]> } };
+    const renderedItems = () =>
+      Object.values((model as unknown as VisibleLayoutReader).getVisibleLayout().rows).flat(2);
+
+    expect(renderedItems()).toEqual(['field-1', 'field-2', 'field-3']);
+    model.toggleFormFieldsCollapse(true, 1);
+    expect(renderedItems()).toEqual(['field-1']);
+    model.toggleFormFieldsCollapse(false, 1);
+    expect(renderedItems()).toEqual(['field-1', 'field-2', 'field-3']);
+    expect(model.getStepParams(GRID_FLOW_KEY, GRID_STEP).rows).toEqual(rows);
+  });
+
   it('uses rowOrder from the full layout when collapsing after reorder', () => {
     const model = engine.createModel<FilterFormGridModel>({
       uid: 'filter-grid-collapse-order',

--- a/packages/plugins/@nocobase/plugin-users/src/client-v2/__tests__/UsersSettingsForm.test.tsx
+++ b/packages/plugins/@nocobase/plugin-users/src/client-v2/__tests__/UsersSettingsForm.test.tsx
@@ -71,8 +71,8 @@ describe('UsersSettingsForm', () => {
 
     await waitFor(() => {
       expect(screen.getByLabelText('Allow edit profile')).not.toBeChecked();
+      expect(screen.getByLabelText('Allow change password')).toBeChecked();
     });
-    expect(screen.getByLabelText('Allow change password')).toBeChecked();
 
     fireEvent.click(screen.getByLabelText('Allow edit profile'));
     fireEvent.click(screen.getByRole('button', { name: 'Save' }));


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
移动端筛选表单点击“折叠”后，按钮文字会变化，但所有字段仍然显示，表单没有收起。

### Description
修复移动端布局重新显示已折叠字段的问题。折叠后只显示配置数量的字段，展开后恢复全部字段并保留输入值，普通模式和界面配置模式均生效。

改动仅涉及移动端布局转换，不修改保存的布局或 API。已验证相关栅格和筛选表单的 10 个测试文件、75 个用例，新增用例在修复前失败、修复后通过；ESLint 和三份独立代码审查通过。Playwright 已验证两种模式下的折叠、展开、表单高度和输入值保留。

建议回归移动端筛选表单的折叠与展开，并检查其他移动端区块布局。未逐一人工验证所有插件页面。

### Showcase
折叠时仅显示首个字段，展开后恢复全部三个字段，表单高度随之变化。

### Changelog

| Language | Changelog |
| --- | --- |
| 🇺🇸 English | Fix filter forms not collapsing on mobile |
| 🇨🇳 Chinese | 修复移动端筛选表单点击折叠无效果的问题 |

### Docs

无需更新文档

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
