### PR TITLE
fix(client): keep filter option input focused

### DIFF
--- a/packages/core/client-v2/src/flow/models/blocks/filter-form/fields/FieldComponentProps.tsx
+++ b/packages/core/client-v2/src/flow/models/blocks/filter-form/fields/FieldComponentProps.tsx
@@ -351,7 +351,7 @@ export const FieldComponentProps: React.FC<{ fieldModel: string; source: string[
       <FormItem label={t('Options')}>
         <Space direction="vertical" size={8} style={{ width: '100%' }}>
           {options.map((option: any, index: number) => (
-            <Space key={`${option.value}-${index}`} style={{ width: '100%' }} size={8} wrap align="start">
+            <Space key={index} style={{ width: '100%' }} size={8} wrap align="start">
               <Input
                 style={{ flex: 1, minWidth: 120 }}
                 placeholder={t('Option label')}

--- a/packages/core/client-v2/src/flow/models/blocks/filter-form/fields/__tests__/FieldComponentProps.options.test.tsx
+++ b/packages/core/client-v2/src/flow/models/blocks/filter-form/fields/__tests__/FieldComponentProps.options.test.tsx
@@ -1,0 +1,61 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+import { createForm } from '@formily/core';
+import { Field, FormProvider } from '@formily/react';
+import { render, screen } from '@nocobase/test/client';
+import userEvent from '@testing-library/user-event';
+import { FlowEngine, FlowEngineProvider, FlowModel, FlowModelProvider } from '@nocobase/flow-engine';
+import { FieldComponentProps } from '../FieldComponentProps';
+
+class HostModel extends FlowModel {
+  render() {
+    return null;
+  }
+}
+
+describe.each(['RadioGroupFieldModel', 'CheckboxGroupFieldModel', 'SelectFieldModel'])('%s options', (fieldModel) => {
+  it('keeps focus while editing option values and preserves remaining rows after removal', async () => {
+    const form = createForm();
+    const engine = new FlowEngine();
+    engine.registerModels({ HostModel });
+    const model = engine.createModel<HostModel>({ use: 'HostModel' });
+    render(
+      <FlowEngineProvider engine={engine}>
+        <FlowModelProvider model={model}>
+          <FormProvider form={form}>
+            <Field name="props" component={[FieldComponentProps, { fieldModel, source: [] }]} />
+          </FormProvider>
+        </FlowModelProvider>
+      </FlowEngineProvider>,
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'plus Add' }));
+    const valueInput = screen.getByPlaceholderText('Option value');
+    await userEvent.type(valueInput, 'abcdef');
+    expect(screen.getByPlaceholderText('Option value')).toHaveValue('abcdef');
+    expect(valueInput).toHaveFocus();
+
+    await userEvent.keyboard('{Backspace}{Backspace}xy');
+    expect(valueInput).toHaveValue('abcdxy');
+    expect(valueInput).toHaveFocus();
+    await userEvent.type(screen.getByPlaceholderText('Option label'), 'First');
+    await userEvent.click(screen.getByRole('button', { name: 'plus Add' }));
+    await userEvent.type(screen.getAllByPlaceholderText('Option label')[1], 'Second');
+    await userEvent.type(screen.getAllByPlaceholderText('Option value')[1], 'second');
+    await userEvent.click(screen.getAllByRole('button', { name: 'close' })[0]);
+    expect(screen.getByPlaceholderText('Option label')).toHaveValue('Second');
+    expect(screen.getByPlaceholderText('Option value')).toHaveValue('second');
+    await userEvent.type(screen.getByPlaceholderText('Option value'), '2');
+    expect(screen.getByPlaceholderText('Option value')).toHaveFocus();
+    expect(form.values.props.options).toEqual([{ label: 'Second', value: 'second2' }]);
+  });
+});


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

筛选表单添加自定义单选框或复选框字段时，选项值每输入一个字符就失去焦点，无法连续输入。

### Description

修复选项值输入时失去焦点的问题，使连续输入、退格和继续编辑正常工作，并补充单选框、复选框和下拉选择的回归测试。

验证：相关 13 个测试文件、93 个用例全部通过；浏览器已验证单选框和复选框连续输入、退格后追加内容均保持焦点。建议同时检查删除一组选项后，其余选项的标签和值仍正确。

本次不改变字段配置格式。ESLint 无错误，存在 5 条与修改前一致的 Hook 依赖警告。

### Showcase

单选框输入 `abcdef` 后，退格并追加 `XYZ`，结果为 `abcdeXYZ`；复选框同样支持连续编辑，输入焦点保持正常。

### Changelog

| Language | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix interrupted option value input for custom radio and checkbox fields in filter forms |
| 🇨🇳 Chinese | 修复筛选表单自定义单选框和复选框的选项值无法连续输入的问题 |

### Docs

| Language | Link |
| ---------- | --------- |
| 🇺🇸 English | 不涉及文档变更 |
| 🇨🇳 Chinese | 不涉及文档变更 |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
