### PR TITLE
feat(plugin-ai): add aimlapi.com as an LLM provider

### DIFF
--- a/packages/plugins/@nocobase/plugin-ai/src/client-v2/__tests__/llm-providers.test.tsx
+++ b/packages/plugins/@nocobase/plugin-ai/src/client-v2/__tests__/llm-providers.test.tsx
@@ -11,6 +11,7 @@ import { describe, expect, it } from 'vitest';
 import { createMockClient } from '@nocobase/client-v2';
 import PluginAIClientV2 from '../plugin';
 import {
+  aimlapiProviderOptions,
   builtinLLMProviderOptions,
   deepseekProviderOptions,
   getBuiltinLLMProviderModelOptionFields,
@@ -20,6 +21,7 @@ import {
   shengsuanyunProviderOptions,
 } from '../llm-providers';
 import {
+  AimlapiProviderSettingsForm,
   EmptyProviderSettingsForm,
   OrcaRouterProviderSettingsForm,
   ProviderSettingsForm,
@@ -40,6 +42,7 @@ const V1_REGISTERED_PROVIDERS = [
   'mistral',
   'orcarouter',
   'shengsuanyun',
+  'aimlapi',
 ];
 
 describe('plugin-ai client-v2 LLM providers', () => {
@@ -59,6 +62,7 @@ describe('plugin-ai client-v2 LLM providers', () => {
     expect(plugin.aiManager.llmProviders.get('ollama')).toBe(ollamaProviderOptions);
     expect(plugin.aiManager.llmProviders.get('orcarouter')).toBe(orcarouterProviderOptions);
     expect(plugin.aiManager.llmProviders.get('shengsuanyun')).toBe(shengsuanyunProviderOptions);
+    expect(plugin.aiManager.llmProviders.get('aimlapi')).toBe(aimlapiProviderOptions);
   });
 
   it('uses v2 provider settings components without v1 schema forms', () => {
@@ -66,6 +70,7 @@ describe('plugin-ai client-v2 LLM providers', () => {
     expect(ollamaProviderOptions.components.ProviderSettingsForm).toBe(EmptyProviderSettingsForm);
     expect(orcarouterProviderOptions.components.ProviderSettingsForm).toBe(OrcaRouterProviderSettingsForm);
     expect(shengsuanyunProviderOptions.components.ProviderSettingsForm).toBe(ShengSuanYunProviderSettingsForm);
+    expect(aimlapiProviderOptions.components.ProviderSettingsForm).toBe(AimlapiProviderSettingsForm);
     expect(shengsuanyunProviderOptions.components.ModelSettingsForm).toBeDefined();
     expect(openaiResponsesProviderOptions.components.ModelSettingsForm).toBeDefined();
   });

--- a/packages/plugins/@nocobase/plugin-ai/src/client-v2/llm-providers/forms.tsx
+++ b/packages/plugins/@nocobase/plugin-ai/src/client-v2/llm-providers/forms.tsx
@@ -89,6 +89,32 @@ export const OrcaRouterProviderSettingsForm: React.FC = () => {
   );
 };
 
+export const AimlapiProviderSettingsForm: React.FC = () => {
+  const t = useT();
+
+  return (
+    <>
+      <Form.Item name={['options', 'apiKey']} label={t('API Key')} rules={[{ required: true }]}>
+        <EnvVariableInput password />
+      </Form.Item>
+      <Form.Item
+        name={['options', 'httpReferer']}
+        label={t('HTTP Referer')}
+        tooltip={t('Optional. Sent as the "HTTP-Referer" header for app attribution.')}
+      >
+        <Input />
+      </Form.Item>
+      <Form.Item
+        name={['options', 'xTitle']}
+        label={t('App Title')}
+        tooltip={t('Optional. Sent as the "X-Title" header for app attribution.')}
+      >
+        <Input />
+      </Form.Item>
+    </>
+  );
+};
+
 export const ShengSuanYunProviderSettingsForm: React.FC = () => {
   const t = useT();
 

--- a/packages/plugins/@nocobase/plugin-ai/src/client-v2/llm-providers/index.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/client-v2/llm-providers/index.ts
@@ -9,6 +9,7 @@
 
 import type { LLMProviderOptions } from '../manager/ai-manager';
 import {
+  AimlapiProviderSettingsForm,
   createModelSettingsForm,
   deepSeekCompletionFields,
   EmptyProviderSettingsForm,
@@ -83,6 +84,10 @@ export const shengsuanyunProviderOptions = createProviderOptions(
   },
 );
 
+export const aimlapiProviderOptions = createProviderOptions(createModelSettingsForm(openAICompletionFields), {
+  ProviderSettingsForm: AimlapiProviderSettingsForm,
+});
+
 export const ollamaProviderOptions = createProviderOptions(createModelSettingsForm(ollamaCompletionFields), {
   ProviderSettingsForm: EmptyProviderSettingsForm,
 });
@@ -101,6 +106,7 @@ export const builtinLLMProviderOptions: Array<[string, LLMProviderOptions]> = [
   ['mistral', mistralProviderOptions],
   ['orcarouter', orcarouterProviderOptions],
   ['shengsuanyun', shengsuanyunProviderOptions],
+  ['aimlapi', aimlapiProviderOptions],
 ];
 
 const builtinLLMProviderModelOptionFields = new Map<string, OptionField[]>([
@@ -117,6 +123,7 @@ const builtinLLMProviderModelOptionFields = new Map<string, OptionField[]>([
   ['mistral', mistralCompletionFields],
   ['orcarouter', orcaRouterCompletionFields],
   ['shengsuanyun', shengSuanYunCompletionFields],
+  ['aimlapi', openAICompletionFields],
 ]);
 
 export const getBuiltinLLMProviderModelOptionFields = (provider?: string): OptionField[] =>

--- a/packages/plugins/@nocobase/plugin-ai/src/client-v2/pages/LLMServicesPage.tsx
+++ b/packages/plugins/@nocobase/plugin-ai/src/client-v2/pages/LLMServicesPage.tsx
@@ -374,6 +374,7 @@ const getProviderDescription = (provider: string, t: ReturnType<typeof useT>) =>
     mistral: 'Mistral models',
     orcarouter: 'OrcaRouter (model routing gateway)',
     shengsuanyun: '300+ latest mainstream models across leading model families',
+    aimlapi: 'Models from OpenAI, Anthropic, Google, DeepSeek and others through one OpenAI-compatible API',
   };
   return descriptions[provider] ? t(descriptions[provider]) : '';
 };

--- a/packages/plugins/@nocobase/plugin-ai/src/locale/en-US.json
+++ b/packages/plugins/@nocobase/plugin-ai/src/locale/en-US.json
@@ -198,6 +198,7 @@
   "Messages": "Messages",
   "Mistral models": "Mistral models",
   "300+ latest mainstream models across leading model families": "300+ latest mainstream models across leading model families",
+  "Models from OpenAI, Anthropic, Google, DeepSeek and others through one OpenAI-compatible API": "Models from OpenAI, Anthropic, Google, DeepSeek and others through one OpenAI-compatible API",
   "Model": "Model",
   "Model ID already exists": "Model ID already exists",
   "Model ID is required": "Model ID is required",

--- a/packages/plugins/@nocobase/plugin-ai/src/locale/zh-CN.json
+++ b/packages/plugins/@nocobase/plugin-ai/src/locale/zh-CN.json
@@ -199,6 +199,7 @@
   "Messages": "消息",
   "Mistral models": "Mistral 模型",
   "300+ latest mainstream models across leading model families": "300+最新各系列主流模型",
+  "Models from OpenAI, Anthropic, Google, DeepSeek and others through one OpenAI-compatible API": "通过一个 OpenAI 兼容 API 使用 OpenAI、Anthropic、Google、DeepSeek 等厂商的模型",
   "Model": "模型",
   "Model ID already exists": "模型标识已存在",
   "Model ID is required": "请输入模型标识",

--- a/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/__tests__/aimlapi.test.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/__tests__/aimlapi.test.ts
@@ -1,0 +1,241 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import type { Application } from '@nocobase/server';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const serverRequestMock = vi.hoisted(() => vi.fn());
+
+vi.mock('@nocobase/utils', async (importOriginal) => {
+  const original = await importOriginal<typeof import('@nocobase/utils')>();
+  return {
+    ...original,
+    serverRequest: serverRequestMock,
+  };
+});
+
+import {
+  AIMLAPI_ATTRIBUTION_HEADERS,
+  AimlapiEmbeddingProvider,
+  AimlapiProvider,
+  aimlapiProviderOptions,
+  supportsChatCompletions,
+  supportsEmbeddings,
+} from '../aimlapi';
+import { SupportedModel } from '../../manager/ai-manager';
+
+function createApp(): Application {
+  return {
+    environment: {
+      renderJsonTemplate: (value: Record<string, unknown>) => value,
+    },
+  } as unknown as Application;
+}
+
+const originalWhitelist = process.env.SERVER_REQUEST_WHITELIST;
+
+describe('AimlapiProvider', () => {
+  afterEach(() => {
+    process.env.SERVER_REQUEST_WHITELIST = originalWhitelist;
+    serverRequestMock.mockReset();
+  });
+
+  it('uses the AI/ML API OpenAI-compatible API base URL', () => {
+    const provider = new AimlapiProvider({
+      app: createApp(),
+      serviceOptions: { apiKey: 'test-key' },
+    });
+
+    expect(provider.baseURL).toBe('https://api.aimlapi.com/v1');
+  });
+
+  it('uses the aimlapi.com brand name in provider selectors', () => {
+    expect(aimlapiProviderOptions.title).toBe('aimlapi.com');
+  });
+
+  // A partner id that does not match the gateway's pattern is dropped silently: the request still succeeds, it is
+  // simply never attributed. A typo would therefore be invisible at runtime, hence this assertion.
+  it('ships a partner id in the format the gateway accepts', () => {
+    expect(AIMLAPI_ATTRIBUTION_HEADERS['X-AIMLAPI-Partner-ID']).toMatch(/^part_[A-Za-z0-9]{1,64}$/);
+  });
+
+  it('ships a source in the <channel>/<client> format the gateway accepts', () => {
+    expect(AIMLAPI_ATTRIBUTION_HEADERS['X-AIMLAPI-Source']).toMatch(/^(web|agent|mcp)\/[a-z0-9-]{1,32}$/);
+  });
+
+  it('identifies NocoBase, not AI/ML API, as the calling application', () => {
+    expect(AIMLAPI_ATTRIBUTION_HEADERS['HTTP-Referer']).toBe('https://github.com/nocobase/nocobase');
+    expect(AIMLAPI_ATTRIBUTION_HEADERS['X-Title']).toBe('NocoBase');
+  });
+
+  it('adds the attribution headers to chat requests', () => {
+    process.env.SERVER_REQUEST_WHITELIST = 'api.aimlapi.com';
+    const provider = new AimlapiProvider({
+      app: createApp(),
+      serviceOptions: { apiKey: 'test-key' },
+      modelOptions: { model: 'openai/gpt-4o-mini' },
+    });
+
+    expect(provider.chatModel.clientConfig).toMatchObject({
+      baseURL: 'https://api.aimlapi.com/v1',
+      defaultHeaders: { ...AIMLAPI_ATTRIBUTION_HEADERS },
+    });
+  });
+
+  it('lets a configured referer and title win over the defaults without dropping the AI/ML API headers', () => {
+    process.env.SERVER_REQUEST_WHITELIST = 'api.aimlapi.com';
+    const provider = new AimlapiProvider({
+      app: createApp(),
+      serviceOptions: { apiKey: 'test-key', httpReferer: 'https://example.test', xTitle: 'Test App' },
+      modelOptions: { model: 'openai/gpt-4o-mini' },
+    });
+
+    expect(provider.chatModel.clientConfig.defaultHeaders).toEqual({
+      'HTTP-Referer': 'https://example.test',
+      'X-Title': 'Test App',
+      'X-AIMLAPI-Partner-ID': AIMLAPI_ATTRIBUTION_HEADERS['X-AIMLAPI-Partner-ID'],
+      'X-AIMLAPI-Source': AIMLAPI_ATTRIBUTION_HEADERS['X-AIMLAPI-Source'],
+    });
+    expect(AIMLAPI_ATTRIBUTION_HEADERS['X-Title']).toBe('NocoBase');
+  });
+
+  // baseURL is user-configurable. Attribution that rode along to another vendor, or to a proxy fronting AI/ML API,
+  // would tag traffic that is not ours.
+  it('does not send attribution to a base URL outside the AI/ML API origin', () => {
+    process.env.SERVER_REQUEST_WHITELIST = 'api.aimlapi.com,proxy.example.test';
+    const provider = new AimlapiProvider({
+      app: createApp(),
+      serviceOptions: { apiKey: 'test-key', baseURL: 'https://proxy.example.test/v1' },
+      modelOptions: { model: 'openai/gpt-4o-mini' },
+    });
+
+    expect(provider.chatModel.clientConfig.defaultHeaders).toBeUndefined();
+  });
+
+  it('recognizes Chat Completions-compatible models', () => {
+    expect(supportsChatCompletions({ id: 'openai/gpt-4o', type: 'openai/chat-completions' })).toBe(true);
+    expect(supportsChatCompletions({ id: 'openai/o3-deep-research', type: 'openai/responses/submit' })).toBe(false);
+    expect(supportsChatCompletions({ id: 'flux/dev', type: 'openai/image-generations' })).toBe(false);
+    expect(supportsChatCompletions({ id: 'legacy-model' })).toBe(true);
+  });
+
+  it('loads and filters the model catalog with the attribution headers attached', async () => {
+    process.env.SERVER_REQUEST_WHITELIST = 'api.aimlapi.com';
+    serverRequestMock.mockResolvedValue({
+      data: {
+        object: 'list',
+        data: [
+          { id: 'openai/gpt-4o', type: 'openai/chat-completions' },
+          { id: 'flux/dev', type: 'openai/image-generations' },
+          { id: 'legacy-model' },
+        ],
+      },
+    });
+    const provider = new AimlapiProvider({
+      app: createApp(),
+      serviceOptions: { apiKey: 'test-key' },
+    });
+
+    await expect(provider.listModels()).resolves.toEqual({
+      models: [{ id: 'openai/gpt-4o' }, { id: 'legacy-model' }],
+    });
+    expect(serverRequestMock).toHaveBeenCalledWith({
+      method: 'GET',
+      url: 'https://api.aimlapi.com/v1/models',
+      headers: {
+        Authorization: 'Bearer test-key',
+        ...AIMLAPI_ATTRIBUTION_HEADERS,
+      },
+    });
+  });
+
+  it('requires an API key before loading models', async () => {
+    process.env.SERVER_REQUEST_WHITELIST = 'api.aimlapi.com';
+    const provider = new AimlapiProvider({
+      app: createApp(),
+    });
+
+    await expect(provider.listModels()).resolves.toEqual({
+      code: 400,
+      errMsg: 'API Key required',
+    });
+    expect(serverRequestMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('AimlapiEmbeddingProvider', () => {
+  // The base class refuses a base URL that is not whitelisted, so it has to be set before construction.
+  beforeEach(() => {
+    process.env.SERVER_REQUEST_WHITELIST = 'api.aimlapi.com,example.invalid';
+  });
+
+  afterEach(() => {
+    process.env.SERVER_REQUEST_WHITELIST = originalWhitelist;
+  });
+
+  const build = (serviceOptions: Record<string, unknown> = {}) =>
+    new AimlapiEmbeddingProvider({
+      app: createApp(),
+      serviceOptions: { apiKey: 'test-key', ...serviceOptions },
+      modelOptions: { model: 'openai/text-embedding-3-small' },
+    });
+
+  it('defaults to the AI/ML API embeddings surface', () => {
+    expect(build().createEmbedding()).toMatchObject({
+      model: 'openai/text-embedding-3-small',
+    });
+  });
+
+  it('attributes embedding traffic, not only chat', () => {
+    const embeddings = build().createEmbedding() as unknown as {
+      clientConfig: { baseURL: string; defaultHeaders?: Record<string, string> };
+    };
+
+    expect(embeddings.clientConfig).toMatchObject({
+      baseURL: 'https://api.aimlapi.com/v1',
+      defaultHeaders: { ...AIMLAPI_ATTRIBUTION_HEADERS },
+    });
+  });
+
+  // Same rule the chat provider follows: baseURL is user-configurable, so it may point at another vendor or at a
+  // proxy fronting this API, and neither should receive our partner id.
+  it('withholds attribution when the base URL is not AI/ML API', () => {
+    const embeddings = build({ baseURL: 'https://example.invalid/v1' }).createEmbedding() as unknown as {
+      clientConfig: { defaultHeaders?: Record<string, string> };
+    };
+
+    expect(embeddings.clientConfig.defaultHeaders).toBeUndefined();
+  });
+});
+
+describe('embedding model discovery', () => {
+  // The chat predicate keeps untyped entries, because a foreign OpenAI-compatible catalog may carry no type at all.
+  // The embedding predicate must not: an untyped entry is a chat model, and offering it here 404s at the first index.
+  it('accepts only entries the catalog marks as embeddings', () => {
+    expect(supportsEmbeddings({ id: 'openai/text-embedding-3-small', type: 'openai/embeddings' })).toBe(true);
+    expect(supportsEmbeddings({ id: 'openai/gpt-4o-mini', type: 'openai/chat-completions' })).toBe(false);
+    expect(supportsEmbeddings({ id: 'some/model' })).toBe(false);
+    expect(supportsChatCompletions({ id: 'some/model' })).toBe(true);
+  });
+
+  it('offers embeddings as a selectable model kind', () => {
+    expect(aimlapiProviderOptions.supportedModel).toContain(SupportedModel.EMBEDDING);
+    expect(aimlapiProviderOptions.embedding).toBe(AimlapiEmbeddingProvider);
+  });
+
+  // The picker reads a static list per model kind rather than calling the provider, so an empty list here would make
+  // the provider selectable and then offer nothing to select.
+  it('enumerates embedding models for the picker', () => {
+    const models = aimlapiProviderOptions.models?.[SupportedModel.EMBEDDING] ?? [];
+
+    expect(models.length).toBeGreaterThan(0);
+    expect(models).toContain('openai/text-embedding-3-small');
+    expect(models.every((id) => typeof id === 'string' && id.includes('/'))).toBe(true);
+  });
+});

--- a/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/aimlapi.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/aimlapi.ts
@@ -1,0 +1,221 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { ChatOpenAI, OpenAIEmbeddings } from '@langchain/openai';
+import { serverRequest } from '@nocobase/utils';
+import { LLMProviderMeta, SupportedModel } from '../manager/ai-manager';
+import { EmbeddingProvider, LLMProvider } from './provider';
+import { EmbeddingsInterface } from '@langchain/core/embeddings';
+
+const AIMLAPI_BASE_URL = 'https://api.aimlapi.com/v1';
+const AIMLAPI_HOSTNAME = 'api.aimlapi.com';
+const CHAT_COMPLETIONS_MODEL_TYPE = 'openai/chat-completions';
+const EMBEDDINGS_MODEL_TYPE = 'openai/embeddings';
+
+/**
+ * Attribution headers sent with every AI/ML API request. `HTTP-Referer` and `X-Title` follow the OpenRouter
+ * convention and identify the calling application (NocoBase, not AI/ML API); the `X-AIMLAPI-*` pair identifies the
+ * integration itself so AI/ML API can attribute traffic to it. Frozen because it is shared by every provider
+ * instance — callers get a copy, never this object.
+ */
+export const AIMLAPI_ATTRIBUTION_HEADERS: Readonly<Record<string, string>> = Object.freeze({
+  'HTTP-Referer': 'https://github.com/nocobase/nocobase',
+  'X-Title': 'NocoBase',
+  'X-AIMLAPI-Partner-ID': 'part_vIQFIgEDs9Yk0yizVcgoM5Sp',
+  'X-AIMLAPI-Source': 'agent/nocobase',
+});
+
+export type AimlapiModel = {
+  id: string;
+  type?: string;
+};
+
+/**
+ * The catalog exposes every endpoint family (image, video, speech, embeddings, ...) under the same list, so entries
+ * have to be narrowed to the Chat Completions surface this provider talks to. Entries with no `type` are kept: a user
+ * may point `baseURL` at another OpenAI-compatible endpoint whose catalog carries no such metadata.
+ */
+export function supportsChatCompletions(model: AimlapiModel): boolean {
+  return typeof model.type !== 'string' || model.type === CHAT_COMPLETIONS_MODEL_TYPE;
+}
+
+/**
+ * Embedding models are the same catalog entries under a different endpoint family. Unlike the chat predicate this one
+ * does NOT accept entries without a `type`: an untyped entry is a chat model on a foreign OpenAI-compatible base URL,
+ * and offering it as an embedding model would produce a 404 at the first index build.
+ */
+export function supportsEmbeddings(model: AimlapiModel): boolean {
+  return model.type === EMBEDDINGS_MODEL_TYPE;
+}
+
+export class AimlapiProvider extends LLMProvider {
+  declare chatModel: ChatOpenAI;
+
+  get baseURL() {
+    return AIMLAPI_BASE_URL;
+  }
+
+  /**
+   * Attribution travels to AI/ML API only. `baseURL` is user-configurable, so it may point at another vendor or at a
+   * proxy that merely fronts the same API, and neither should receive these headers.
+   */
+  protected buildDefaultHeaders(): Record<string, string> {
+    const { httpReferer, xTitle } = this.serviceOptions || {};
+    const headers: Record<string, string> = this.isAimlapiOrigin() ? { ...AIMLAPI_ATTRIBUTION_HEADERS } : {};
+    if (httpReferer) {
+      headers['HTTP-Referer'] = httpReferer;
+    }
+    if (xTitle) {
+      headers['X-Title'] = xTitle;
+    }
+    return headers;
+  }
+
+  protected isAimlapiOrigin(): boolean {
+    try {
+      return new URL(this.getResolvedBaseURL()).hostname === AIMLAPI_HOSTNAME;
+    } catch {
+      return false;
+    }
+  }
+
+  createModel() {
+    const { apiKey } = this.serviceOptions || {};
+    const { responseFormat, structuredOutput } = this.modelOptions || {};
+    const { name, schema } = structuredOutput || {};
+    const responseFormatOptions: Record<string, unknown> = {
+      type: responseFormat ?? 'text',
+    };
+
+    if (responseFormat === 'json_schema' && schema) {
+      responseFormatOptions.json_schema = {
+        schema,
+        name: name ?? 'schema',
+      };
+    }
+
+    const defaultHeaders = this.buildDefaultHeaders();
+
+    return new ChatOpenAI({
+      apiKey,
+      ...this.modelOptions,
+      modelKwargs: {
+        response_format: responseFormatOptions,
+      },
+      configuration: {
+        baseURL: this.getResolvedBaseURL(),
+        ...(Object.keys(defaultHeaders).length ? { defaultHeaders } : {}),
+      },
+    });
+  }
+
+  async listModels(): Promise<{
+    models?: { id: string }[];
+    code?: number;
+    errMsg?: string;
+  }> {
+    const { apiKey } = this.serviceOptions || {};
+    let url: string;
+
+    try {
+      url = this.buildRequestURL('models');
+    } catch (error) {
+      return { code: 400, errMsg: error instanceof Error ? error.message : String(error) };
+    }
+
+    if (!apiKey) {
+      return { code: 400, errMsg: 'API Key required' };
+    }
+
+    try {
+      const response = await serverRequest({
+        method: 'GET',
+        url,
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          ...this.buildDefaultHeaders(),
+        },
+      });
+      const models = Array.isArray(response?.data?.data) ? (response.data.data as AimlapiModel[]) : [];
+
+      return {
+        models: models.filter(supportsChatCompletions).map(({ id }) => ({ id })),
+      };
+    } catch (error) {
+      return {
+        code: 500,
+        errMsg: error instanceof Error ? error.message : String(error),
+      };
+    }
+  }
+}
+
+/**
+ * Embeddings run over the same OpenAI-compatible surface and the same key as chat, so this mirrors the chat provider
+ * rather than inventing a second transport: `baseURL` stays user-configurable, and attribution is attached under the
+ * same rule — only when the resolved host is AI/ML API itself.
+ */
+export class AimlapiEmbeddingProvider extends EmbeddingProvider {
+  protected getDefaultUrl(): string {
+    return AIMLAPI_BASE_URL;
+  }
+
+  protected isAimlapiOrigin(): boolean {
+    try {
+      return new URL(this.baseURL).hostname === AIMLAPI_HOSTNAME;
+    } catch {
+      return false;
+    }
+  }
+
+  createEmbedding(): EmbeddingsInterface {
+    const defaultHeaders = this.isAimlapiOrigin() ? { ...AIMLAPI_ATTRIBUTION_HEADERS } : undefined;
+
+    return new OpenAIEmbeddings({
+      model: this.model,
+      configuration: {
+        baseURL: this.baseURL,
+        apiKey: this.apiKey,
+        ...(defaultHeaders ? { defaultHeaders } : {}),
+      },
+    });
+  }
+}
+
+export const aimlapiProviderOptions: LLMProviderMeta = {
+  title: 'aimlapi.com',
+  supportedModel: [SupportedModel.LLM, SupportedModel.EMBEDDING],
+  /**
+   * Chat models are discovered live through `listModels`, which is why no LLM list appears here. Embedding models are
+   * enumerated instead: the catalog carries far more of them than are useful as a default, and the picker asks for a
+   * static list per model kind rather than calling the provider. Regenerate from
+   * `GET /v1/models` filtered on `type === 'openai/embeddings'` when the catalog gains one.
+   */
+  models: {
+    [SupportedModel.EMBEDDING]: [
+      'alibaba/qwen-text-embedding-v3',
+      'alibaba/qwen-text-embedding-v4',
+      'alibaba/text-embedding-v3',
+      'alibaba/text-embedding-v4',
+      'anthropic/voyage-2',
+      'anthropic/voyage-code-2',
+      'anthropic/voyage-finance-2',
+      'anthropic/voyage-large-2',
+      'anthropic/voyage-large-2-instruct',
+      'anthropic/voyage-law-2',
+      'anthropic/voyage-multilingual-2',
+      'google/text-multilingual-embedding-002',
+      'openai/text-embedding-3-large',
+      'openai/text-embedding-3-small',
+      'openai/text-embedding-ada-002',
+    ],
+  },
+  provider: AimlapiProvider,
+  embedding: AimlapiEmbeddingProvider,
+};

--- a/packages/plugins/@nocobase/plugin-ai/src/server/plugin.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/plugin.ts
@@ -48,6 +48,7 @@ import { mimoProviderOptions } from './llm-providers/mimo';
 import { mistralProviderOptions } from './llm-providers/mistral';
 import { orcarouterProviderOptions } from './llm-providers/orcarouter';
 import { shengsuanyunProviderOptions } from './llm-providers/shengsuanyun';
+import { aimlapiProviderOptions } from './llm-providers/aimlapi';
 import { SubAgentsDispatcher } from './ai-employees/sub-agents';
 import {
   AIEmployeeInstruction,
@@ -189,6 +190,7 @@ export class PluginAIServer extends Plugin {
     this.aiManager.registerLLMProvider('xai', xaiProviderOptions);
     this.aiManager.registerLLMProvider('orcarouter', orcarouterProviderOptions);
     this.aiManager.registerLLMProvider('shengsuanyun', shengsuanyunProviderOptions);
+    this.aiManager.registerLLMProvider('aimlapi', aimlapiProviderOptions);
   }
 
   registerTools() {

--- a/packages/plugins/@nocobase/plugin-ai/src/server/resource/ai.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/resource/ai.ts
@@ -68,7 +68,7 @@ const aiResource: ResourceOptions = {
         serviceOptions: options,
       });
       if (model && providerOptions.supportedModel.includes(model)) {
-        ctx.body = providerOptions.models?.[model].map((id) => ({ id })) ?? [];
+        ctx.body = providerOptions.models?.[model]?.map((id) => ({ id })) ?? [];
       } else {
         const res = await provider.listModels();
         if (res.errMsg) {


### PR DESCRIPTION
Hi! I'm Hugo from aimlapi.com — an AI aggregator that gives access to 1000+ models in one API, trusted by 400k+ users.

We'd love to be available as a verified provider option inside NocoBase — so we went ahead and did all the technical work on our side.

To build our partnership, we offer a 50/50 revenue share on all traffic from this integration. (P.S.: tracking starts as soon as this release goes live, so no earnings will be lost during setup)

My contacts: hugo@aimlapi.com (email / Slack), Telegram: @hug0the

---

### This is a ...
- [x] New feature
- [ ] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation

Admins can already reach AI/ML API today through `openai-completions` with a custom base URL, so this is not new capability — it buys discoverability, a correct model list and attribution. Configured that way the service shows up in the provider list as "OpenAI (completions)", the model picker is empty unless every id is typed by hand, and nothing tells AI/ML API which application the traffic came from.

This adds aimlapi.com as a first-class provider in plugin-ai — for both chat and embedding models — following the shape of the two most recent provider additions in this repo (shengsuanyun, orcarouter).

### Description

**Server — `src/server/llm-providers/aimlapi.ts`**

- `AimlapiProvider` extends `LLMProvider`: LangChain `ChatOpenAI` over the OpenAI-compatible Chat Completions API. Base URL `https://api.aimlapi.com/v1`, user-overridable per service like every other provider.
- `listModels()` fetches `GET {baseURL}/models` with the configured key and narrows the catalog to entries the Chat Completions client can actually drive (`type === "openai/chat-completions"`). The catalog mixes image, video, speech and embedding models into the same list, so an unfiltered list would offer models that cannot be chatted with. Entries with no `type` are kept, so a user pointing `baseURL` at another OpenAI-compatible endpoint still gets a list. No chat model ids are hardcoded — the list is fetched, so it cannot go stale.
- `AimlapiEmbeddingProvider` extends `EmbeddingProvider` over the same key and the same OpenAI-compatible surface, so AI/ML API also appears where an embedding model is chosen. Its predicate is deliberately stricter than the chat one (`type === "openai/embeddings"` only, untyped entries rejected): an untyped entry is a chat model, and offering it as an embedding model would 404 on the first index build. The model picker reads a static list per model kind rather than calling the provider, so the fifteen embedding ids from the live catalog are enumerated in the provider meta; chat models are still discovered live.
- Attribution headers, following `orcarouter.ts` which already injects `HTTP-Referer` / `X-Title` from service options:
  - `HTTP-Referer: https://github.com/nocobase/nocobase` and `X-Title: NocoBase` — identify NocoBase as the calling application, not AI/ML API, and both stay overridable per service through the settings form.
  - `X-AIMLAPI-Partner-ID` / `X-AIMLAPI-Source` — identify the integration itself.
  - All four are scoped to the `api.aimlapi.com` origin. `baseURL` is user-configurable, so a service could point at another vendor or at a proxy that merely fronts the same API; neither should receive them. Embedding requests attach them under the same rule.
  - The header map is a frozen module constant and every request gets a copy, so per-service overrides can never mutate it.

**Client (v2)** — the provider settings form (API key + optional referer/title, mirroring OrcaRouter's), the provider options registration, and a localized description. `openAICompletionFields` is reused for model options rather than duplicating an identical field list.

**Fix — `src/server/resource/ai.ts`** — `models?.[model].map()` guards the map but not the key, so any provider that declares a supported model kind without a matching static list threw a TypeError in the `listModels` action. This provider (live-discovered chat models + static embedding list) would have been the first to hit it; the fix is one added `?.`.

**i18n** — one new string, added to both en-US and zh-CN.

Risks are contained: no existing behavior changes apart from the optional-chaining guard above. The one shared file with more than an added line is `src/client-v2/llm-providers/index.ts`, where the provider is appended to the two builtin registries.

**Testing suggestions**

- `yarn test packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/__tests__/aimlapi.test.ts --run` — 17 cases covering the base URL, display name, header set, origin scoping, per-service override path, catalog filtering for both model kinds, and the embedding model enumeration. One test asserts the partner id matches `^part_[A-Za-z0-9]{1,64}$` — a malformed id is accepted with a 200 and silently not attributed, so a typo would otherwise be invisible at runtime.
- `yarn test:client packages/plugins/@nocobase/plugin-ai/src/client-v2/__tests__/llm-providers.test.tsx --run` — provider registration assertions extended to aimlapi.
- Verified against the live service through the provider class (not a mock): catalog listing (353 chat models filtered out of 936 catalog entries), a chat completion and a tool call, with the four headers on the wire.
- Not verified: streaming was not exercised live (only the non-streaming invoke path), and the client form was covered by unit tests, not a browser run. No schema change, so no migration.

### Related issues

None — happy to open a tracking issue if that's preferred.

### Showcase

The provider appears in the LLM services list as **aimlapi.com** ("Models from OpenAI, Anthropic, Google, DeepSeek and others through one OpenAI-compatible API"). The settings form is API key + optional `HTTP-Referer` / `X-Title` overrides, same layout as OrcaRouter.

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | feat(plugin-ai): add aimlapi.com as an LLM and embedding provider |
| 🇨🇳 Chinese | feat(plugin-ai): 新增 aimlapi.com 大模型服务商（支持对话与 Embedding 模型） |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | n/a — no doc site page exists for individual LLM providers |
| 🇨🇳 Chinese | n/a |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
