### PR TITLE
fix(data-source-manager): preserve inverse field selection

### DIFF
--- a/packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/FieldForm.tsx
+++ b/packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/FieldForm.tsx
@@ -343,7 +343,11 @@ function toInitialValues(
   t: (key: string) => string,
 ) {
   if (field) {
-    return cloneDeep(field);
+    const values = cloneDeep(field);
+    if (values.reverseField) {
+      values.autoCreateReverseField = true;
+    }
+    return values;
   }
   const values = {
     name: randomId('f_'),

--- a/packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/FieldsPage.tsx
+++ b/packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/FieldsPage.tsx
@@ -985,7 +985,6 @@ export default function FieldsPage(props: FieldsPageProps) {
       url: getCollectionFieldActionUrl(props.dataSourceKey, props.collection.name, 'list'),
       params: {
         paginate: false,
-        appends: ['reverseField'],
         filter: JSON.stringify({
           $or: [{ 'interface.$not': null }, { 'options.source.$notEmpty': true }],
         }),
@@ -1050,12 +1049,27 @@ export default function FieldsPage(props: FieldsPageProps) {
   }, [request.data]);
 
   const openFieldForm = useCallback(
-    (
+    async (
       mode: 'create' | 'edit',
       field?: Record<string, any>,
       interfaceName?: string,
       options?: { override?: boolean },
     ) => {
+      let fieldValues = field;
+      if (mode === 'edit' && field?.name) {
+        try {
+          const response = await ctx.api.request({
+            url: getCollectionFieldActionUrl(props.dataSourceKey, props.collection.name, 'get', field.name),
+            params: { appends: ['reverseField'] },
+          });
+          fieldValues = response?.data?.data || field;
+        } catch (error) {
+          notification.error({
+            message: getErrorMessage(error, t('Field loading failed')),
+          });
+          return;
+        }
+      }
       ctx.viewer.drawer({
         width: 800,
         closable: true,
@@ -1065,14 +1079,14 @@ export default function FieldsPage(props: FieldsPageProps) {
             dataSourceKey={props.dataSourceKey}
             collection={props.collection}
             interfaceName={interfaceName}
-            field={field}
+            field={fieldValues}
             override={options?.override}
             onSubmitted={() => request.refresh()}
           />
         ),
       });
     },
-    [ctx.viewer, props.collection, props.dataSourceKey, request],
+    [ctx.api, ctx.viewer, notification, props.collection, props.dataSourceKey, request, t],
   );
 
   const addFieldMenu = useMemo<MenuProps>(
@@ -1212,6 +1226,8 @@ export default function FieldsPage(props: FieldsPageProps) {
 
   const handleFieldInterfaceChange = useCallback(
     async (field: Record<string, any>, nextInterfaceName?: string) => {
+      const fieldValues = { ...field };
+      delete fieldValues.reverseField;
       const nextInterface = nextInterfaceName ? fieldInterfacesByName[nextInterfaceName] : undefined;
       const nextDefault = nextInterface?.default || {};
       const nextUiSchema = nextDefault.uiSchema
@@ -1225,7 +1241,7 @@ export default function FieldsPage(props: FieldsPageProps) {
           url: getCollectionFieldActionUrl(props.dataSourceKey, props.collection.name, 'update', field.name),
           method: 'post',
           data: {
-            ...field,
+            ...fieldValues,
             ...nextDefault,
             name: field.name,
             interface: nextInterfaceName || null,
@@ -1261,13 +1277,15 @@ export default function FieldsPage(props: FieldsPageProps) {
         message.error(t('Field display name is required'));
         throw new Error('Field display name is required');
       }
+      const fieldValues = { ...field };
+      delete fieldValues.reverseField;
       setDisplayNameLoadingKey(field.name);
       try {
         await ctx.api.request({
           url: getCollectionFieldActionUrl(props.dataSourceKey, props.collection.name, 'update', field.name),
           method: 'post',
           data: {
-            ...field,
+            ...fieldValues,
             uiSchema: {
               ...omitRawTitle(field.uiSchema),
               title: nextTitle,

--- a/packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/FieldsPage.tsx
+++ b/packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/FieldsPage.tsx
@@ -985,6 +985,7 @@ export default function FieldsPage(props: FieldsPageProps) {
       url: getCollectionFieldActionUrl(props.dataSourceKey, props.collection.name, 'list'),
       params: {
         paginate: false,
+        appends: ['reverseField'],
         filter: JSON.stringify({
           $or: [{ 'interface.$not': null }, { 'options.source.$notEmpty': true }],
         }),

--- a/packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/__tests__/FieldForm.test.tsx
+++ b/packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/__tests__/FieldForm.test.tsx
@@ -445,6 +445,38 @@ describe('FieldForm', () => {
     expect(onSubmitted).toHaveBeenCalled();
   });
 
+  it('checks the inverse field option when editing a relation with an existing reverse field', async () => {
+    renderFieldForm({
+      mode: 'edit',
+      interfaceName: 'belongsTo',
+      field: {
+        name: 'customer',
+        interface: 'belongsTo',
+        type: 'belongsTo',
+        source: 'orders',
+        target: 'customers',
+        sourceKey: 'id',
+        targetKey: 'id',
+        uiSchema: {
+          title: 'Customer',
+          type: 'object',
+        },
+        reverseField: {
+          key: 'customers.orders',
+          name: 'orders',
+          interface: 'hasMany',
+          type: 'hasMany',
+          uiSchema: {
+            title: 'Orders',
+            type: 'array',
+          },
+        },
+      },
+    });
+
+    expect(await screen.findByRole('checkbox', { name: 'Auto create reverse field' })).toBeChecked();
+  });
+
   it('rebuilds initial values when changing the field interface before creating a field', async () => {
     renderFieldForm({ interfaceName: undefined });
 

--- a/packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/__tests__/FieldsPageComponent.test.tsx
+++ b/packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/__tests__/FieldsPageComponent.test.tsx
@@ -21,7 +21,14 @@ const notifications = {
   error: vi.fn(),
 };
 
-const apiRequest = vi.fn((options: { url: string }) => {
+type ApiRequestOptions = {
+  data?: Record<string, unknown>;
+  method?: string;
+  params?: Record<string, unknown>;
+  url: string;
+};
+
+const apiRequest = vi.fn((options: ApiRequestOptions) => {
   if (options.url === 'collectionFields:list') {
     return Promise.resolve({
       data: {
@@ -32,14 +39,32 @@ const apiRequest = vi.fn((options: { url: string }) => {
             interface: 'input',
             uiSchema: { title: 'Title' },
             description: 'Order title',
+            reverseField: { key: 'customers.orders' },
           },
           {
             name: 'status',
             type: 'string',
             interface: 'select',
             uiSchema: { title: 'Status' },
+            reverseField: { key: 'orders.statuses' },
           },
         ],
+      },
+    });
+  }
+  if (options.url === 'collectionFields:get:title') {
+    return Promise.resolve({
+      data: {
+        data: {
+          name: 'title',
+          type: 'string',
+          interface: 'input',
+          uiSchema: { title: 'Title' },
+          reverseField: {
+            key: 'customers.orders',
+            name: 'orders',
+          },
+        },
       },
     });
   }
@@ -286,23 +311,26 @@ describe('FieldsPage', () => {
 
     expect(await screen.findByTestId('field-row-title')).toBeInTheDocument();
     expect(screen.getByTestId('field-row-status')).toBeInTheDocument();
-    expect(apiRequest).toHaveBeenCalledWith(
-      expect.objectContaining({
-        url: 'collectionFields:list',
-        params: expect.objectContaining({
-          appends: ['reverseField'],
-        }),
-      }),
-    );
+    const listCall = apiRequest.mock.calls.find(([options]) => options.url === 'collectionFields:list')?.[0] as
+      | { params?: Record<string, unknown> }
+      | undefined;
+    expect(listCall?.params?.appends).toBeUndefined();
 
     fireEvent.click(within(screen.getByTestId('field-row-title')).getByText('t:Edit'));
 
-    expect(flowMocks.ctx.viewer.drawer).toHaveBeenCalledWith(
-      expect.objectContaining({
-        closable: true,
-        width: 800,
+    await waitFor(() =>
+      expect(apiRequest).toHaveBeenCalledWith({
+        url: 'collectionFields:get:title',
+        params: { appends: ['reverseField'] },
       }),
     );
+    await waitFor(() => expect(flowMocks.ctx.viewer.drawer).toHaveBeenCalled());
+    const drawerOptions = flowMocks.ctx.viewer.drawer.mock.calls[0][0];
+    expect(drawerOptions).toEqual(expect.objectContaining({ closable: true, width: 800 }));
+    expect(drawerOptions.content().props.field.reverseField).toEqual({
+      key: 'customers.orders',
+      name: 'orders',
+    });
   });
 
   it('saves field display names and title field changes', async () => {
@@ -328,6 +356,10 @@ describe('FieldsPage', () => {
         }),
       ),
     );
+    const displayNameUpdate = apiRequest.mock.calls.find(
+      ([options]) => options.url === 'collectionFields:update:title',
+    )?.[0];
+    expect(displayNameUpdate.data).not.toHaveProperty('reverseField');
 
     fireEvent.click(screen.getByLabelText('switch-title-field-status'));
 
@@ -384,6 +416,10 @@ describe('FieldsPage', () => {
       ),
     );
     expect(mainDataSource.reload).toHaveBeenCalled();
+    const interfaceUpdate = apiRequest.mock.calls.find(
+      ([options]) => options.url === 'collectionFields:update:status',
+    )?.[0];
+    expect(interfaceUpdate?.data).not.toHaveProperty('reverseField');
   });
 
   it('confirms and deletes a configurable field', async () => {

--- a/packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/__tests__/FieldsPageComponent.test.tsx
+++ b/packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/__tests__/FieldsPageComponent.test.tsx
@@ -286,6 +286,14 @@ describe('FieldsPage', () => {
 
     expect(await screen.findByTestId('field-row-title')).toBeInTheDocument();
     expect(screen.getByTestId('field-row-status')).toBeInTheDocument();
+    expect(apiRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: 'collectionFields:list',
+        params: expect.objectContaining({
+          appends: ['reverseField'],
+        }),
+      }),
+    );
 
     fireEvent.click(within(screen.getByTestId('field-row-title')).getByText('t:Edit'));
 

--- a/packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/__tests__/collectionFieldApi.test.ts
+++ b/packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/__tests__/collectionFieldApi.test.ts
@@ -19,6 +19,12 @@ describe('getCollectionFieldActionUrl', () => {
   });
 
   it('appends encoded filterByTk when provided', () => {
+    expect(getCollectionFieldActionUrl('main', 'orders', 'get', 'customer/id')).toBe(
+      'collections/orders/fields:get?filterByTk=customer%2Fid',
+    );
+    expect(getCollectionFieldActionUrl('external', 'orders', 'get', 'customer/id')).toBe(
+      'dataSourcesCollections/external.orders/fields:get?filterByTk=customer%2Fid',
+    );
     expect(getCollectionFieldActionUrl('main', 'orders', 'update', 'title/id')).toBe(
       'collections/orders/fields:update?filterByTk=title%2Fid',
     );

--- a/packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/collectionFieldApi.ts
+++ b/packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/collectionFieldApi.ts
@@ -7,7 +7,7 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-type FieldAction = 'list' | 'create' | 'update' | 'destroy';
+type FieldAction = 'list' | 'get' | 'create' | 'update' | 'destroy';
 
 export function getCollectionFieldActionUrl(
   dataSourceKey: string,

--- a/packages/plugins/@nocobase/plugin-data-source-manager/src/locale/en-US.json
+++ b/packages/plugins/@nocobase/plugin-data-source-manager/src/locale/en-US.json
@@ -191,6 +191,7 @@
   "Source key": "Source key",
   "Status": "Status",
   "Delete failed": "Delete failed",
+  "Field loading failed": "Field loading failed",
   "Save failed": "Save failed",
   "Submit failed": "Submit failed",
   "Store the creation time of each record": "Store the creation time of each record",

--- a/packages/plugins/@nocobase/plugin-data-source-manager/src/locale/zh-CN.json
+++ b/packages/plugins/@nocobase/plugin-data-source-manager/src/locale/zh-CN.json
@@ -191,6 +191,7 @@
   "Source key": "源键",
   "Status": "状态",
   "Delete failed": "删除失败",
+  "Field loading failed": "字段加载失败",
   "Save failed": "保存失败",
   "Submit failed": "提交失败",
   "Store the creation time of each record": "存储每条记录的创建时间",


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

In the v2 data source manager, a relation field created with an inverse field did not show the inverse-field option as selected when the field was edited later.

### Description

- Fetch the current field and its reverse field association only when opening the edit drawer.
- Initialize the inverse-field checkbox as selected when the edited field already has a reverse field.
- Keep field list rows lightweight and exclude reverseField from inline field updates to avoid unintended association writes.
- Add regression coverage for on-demand loading, edit form state, update payload boundaries, and field action URLs.

The change only affects v2 relation-field configuration UI state. It does not change database schemas, permissions, migrations, or relation persistence behavior.

### Related issues

Task 6322

### Showcase

Not applicable.

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed the inverse-field option not remaining selected when editing a v2 relation field. |
| 🇨🇳 Chinese | 修复 v2 关系字段编辑时反向字段选项未保持勾选的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | 无需更新 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary

### Verification

- yarn test packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/__tests__/FieldForm.test.tsx --run --reporter=verbose (6 tests passed)
- yarn test packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/__tests__/FieldsPageComponent.test.tsx --run --reporter=verbose (5 tests passed)
- yarn test packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/__tests__/collectionFieldApi.test.ts --run --reporter=verbose (2 tests passed)
- yarn eslint --fix on the changed files (passed)
- git diff --check (passed)

Remote CI was retriggered by the latest push and has not been observed to completion yet.
