### PR TITLE
fix(client-v2): handle deleted assigned fields

### DIFF
--- a/packages/core/client-v2/src/flow/models/blocks/assign-form/__tests__/assignFieldValuesFlow.editor.test.tsx
+++ b/packages/core/client-v2/src/flow/models/blocks/assign-form/__tests__/assignFieldValuesFlow.editor.test.tsx
@@ -47,6 +47,60 @@ class MockFlowModelRepository implements IFlowModelRepository {
 }
 
 describe('assignFieldValuesFlow (editor)', () => {
+  it('keeps the field selector available when a previously assigned field has been deleted', async () => {
+    const engine = new FlowEngine();
+    engine.setModelRepository(new MockFlowModelRepository());
+    engine.registerModels({
+      AssignFormModel,
+      AssignFormGridModel,
+      AssignFormItemModel,
+      InputFieldModel,
+      VariableFieldFormModel,
+    });
+    engine.context.defineProperty('location', { value: { search: '' } });
+    engine.context.defineProperty('themeToken', { value: { marginLG: 24 } });
+    engine.context.defineProperty('flowSettingsEnabled', { value: true });
+
+    const main = engine.context.dataSourceManager.getDataSource('main');
+    main.addCollection({
+      name: 'users',
+      fields: [{ name: 'nickname', type: 'string', interface: 'input' }],
+    });
+    const users = engine.context.dataSourceManager.getCollection('main', 'users');
+
+    const action = engine.createModel({
+      use: 'FlowModel',
+      uid: 'act-assign-deleted-field',
+    });
+    action.setStepParams('assignSettings', 'assignFieldValues', {
+      assignedValues: { deletedField: 'stale value' },
+    });
+    action.context.defineProperty('blockModel', { value: { collection: users } });
+
+    const step = createAssignFieldValuesStep({ settingsFlowKey: 'assignSettings' });
+    const Editor = step.uiSchema().editor?.['x-component'] as React.ComponentType;
+    const flowSettingsCtx = new FlowRuntimeContext(action, 'assignSettings', 'settings');
+
+    render(
+      <FlowEngineProvider engine={engine}>
+        <ConfigProvider>
+          <App>
+            <FlowSettingsContextProvider value={flowSettingsCtx}>
+              <Editor />
+            </FlowSettingsContextProvider>
+          </App>
+        </ConfigProvider>
+      </FlowEngineProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Fields/ })).toBeInTheDocument();
+      const form = engine.findModelByParentId<AssignFormModel>(action.uid, 'assignForm');
+      expect(form).toBeDefined();
+      expect(form?.subModels.grid.subModels.items || []).toHaveLength(0);
+    });
+  });
+
   it('repairs AssignFormModel resource init and clears cached collection', async () => {
     const engine = new FlowEngine();
     engine.setModelRepository(new MockFlowModelRepository());

--- a/packages/core/flow-engine/src/models/CollectionFieldModel.tsx
+++ b/packages/core/flow-engine/src/models/CollectionFieldModel.tsx
@@ -51,7 +51,7 @@ export function FieldDeletePlaceholder() {
     const dataSourcePrefix = dataSource ? `${t(dataSource.displayName || dataSource.key)} > ` : '';
     const collectionPrefix = collection ? `${t(collection.title) || collection.name || collection.tableName} > ` : '';
     return `${dataSourcePrefix}${collectionPrefix}${name}`;
-  }, []);
+  }, [collection, dataSource, name, t]);
   return (
     <Form.Item>
       <div
@@ -80,7 +80,7 @@ function FieldWithoutPermissionPlaceholder() {
     const dataSourcePrefix = `${t(dataSource.displayName || dataSource.key)} > `;
     const collectionPrefix = collection ? `${t(collection.title) || collection.name || collection.tableName} > ` : '';
     return `${dataSourcePrefix}${collectionPrefix}${name}`;
-  }, []);
+  }, [collection, dataSource.displayName, dataSource.key, name, t]);
   const { actionName } = model.forbidden;
   const messageValue = useMemo(() => {
     return t(
@@ -90,7 +90,7 @@ function FieldWithoutPermissionPlaceholder() {
         actionName: t(_.capitalize(actionName)),
       },
     ).replaceAll('&gt;', '>');
-  }, [nameValue, t]);
+  }, [actionName, nameValue, t]);
 
   return (
     <Tooltip title={messageValue}>
@@ -198,13 +198,16 @@ export class CollectionFieldModel<T extends DefaultStructure = DefaultStructure>
 
   static getDefaultBindingByField(
     ctx: FlowEngineContext,
-    collectionField: CollectionField,
+    collectionField: CollectionField | null | undefined,
     options: {
       useStrict?: boolean;
       fallbackToTargetTitleField?: boolean;
       targetCollectionTitleField?: CollectionField;
     } = {},
   ): BindingOptions | null {
+    if (!collectionField) {
+      return null;
+    }
     if (options.fallbackToTargetTitleField) {
       const binding = this.getDefaultBindingByField(ctx, collectionField, { useStrict: true });
       if (!binding) {

--- a/packages/core/flow-engine/src/models/__tests__/CollectionFieldModel.test.ts
+++ b/packages/core/flow-engine/src/models/__tests__/CollectionFieldModel.test.ts
@@ -108,6 +108,11 @@ describe('CollectionFieldModel', () => {
     expect(defaultBinding).toBeNull();
   });
 
+  it('should return null when the collection field has been deleted', () => {
+    const defaultBinding = TestModel.getDefaultBindingByField(mockContext, undefined);
+    expect(defaultBinding).toBeNull();
+  });
+
   it('should return null if no bindings exist for the interface', () => {
     class Test1Model extends CollectionFieldModel {}
     class Test2Model extends Test1Model {}


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
A v2 table Update record action can retain an assigned field after that field is deleted from the collection. Reopening Field values then passes a missing collection field to the default binding resolver, throws while reading interface, and prevents the Fields button from rendering.

### Description
- Return no binding when the collection field no longer exists.
- Skip stale assigned field entries while keeping the field selector available.
- Add unit and editor regression coverage for the deleted-field scenario.
- Complete existing React hook dependency lists in the touched model file to keep lint clean.

Target base: main.

Current behavior is unchanged for valid collection fields. The new fallback only applies when field resolution returns null or undefined. There are no database migrations, API changes, permission changes, or persistence format changes.

### Related issues
Task 6345

### Showcase
Not included. The regression is covered by an editor rendering test.

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed the v2 Update record field settings failing after an assigned field was deleted. |
| 🇨🇳 Chinese | 修复 v2 更新数据动作中已配置字段被删除后字段设置无法打开的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | 不需要 |

### Verification
- yarn test packages/core/flow-engine/src/models/__tests__/CollectionFieldModel.test.ts --run --reporter=dot — 9 tests passed locally.
- yarn test packages/core/client-v2/src/flow/models/blocks/assign-form/__tests__/assignFieldValuesFlow.editor.test.tsx --run --reporter=dot — 3 tests passed locally.
- yarn eslint --fix on all three touched files — passed with no errors or warnings.
- git diff --check — passed.

Remote CI has not completed yet. No runtime deployment or manual browser verification was performed.

### Risk and review focus
Risk is low. The production behavior change is a null guard in the shared default field-binding resolver. Review should focus on whether returning null is the expected fallback for every missing-field caller; it matches the existing no-binding contract and the sibling binding-list resolver behavior.

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary