### PR TITLE
fix(client-v2): show deleted assigned fields

### DIFF
--- a/packages/core/client-v2/src/flow/models/blocks/assign-form/AssignFormGridModel.tsx
+++ b/packages/core/client-v2/src/flow/models/blocks/assign-form/AssignFormGridModel.tsx
@@ -115,7 +115,28 @@ export class AssignFormGridModel extends FormGridModel {
       (existing as any).assignValue = value;
       return;
     }
-    const field = (collection?.getFields?.() || []).find((f: any) => f.name === fieldName);
+    if (!collection) {
+      return;
+    }
+    const field = (collection.getFields?.() || []).find((f: any) => f.name === fieldName);
+
+    if (!field) {
+      const created = this.addSubModel('items', {
+        use: 'AssignFormItemModel',
+        stepParams: {
+          fieldSettings: {
+            init: {
+              dataSourceKey: collection?.dataSourceKey,
+              collectionName: collection?.name,
+              fieldPath: fieldName,
+            },
+            assignValue: { value },
+          },
+        },
+      });
+      created['assignValue'] = value;
+      return;
+    }
 
     const binding = EditableItemModel.getDefaultBindingByField(this.context, field);
     if (!binding) {

--- a/packages/core/client-v2/src/flow/models/blocks/assign-form/AssignFormItemModel.tsx
+++ b/packages/core/client-v2/src/flow/models/blocks/assign-form/AssignFormItemModel.tsx
@@ -10,7 +10,14 @@
 import React from 'react';
 import { Input } from 'antd';
 import { define, observable } from '@formily/reactive';
-import { FlowModelRenderer, FormItem, tExpr, EditableItemModel, jioToJoiSchema } from '@nocobase/flow-engine';
+import {
+  EditableItemModel,
+  FieldDeletePlaceholder,
+  FlowModelRenderer,
+  FormItem,
+  jioToJoiSchema,
+  tExpr,
+} from '@nocobase/flow-engine';
 // 无需类型导入（避免未使用的类型）
 import { FormItemModel } from '../form/FormItemModel';
 import { EditFormModel } from '../form/EditFormModel';
@@ -160,11 +167,15 @@ export class AssignFormItemModel extends FormItemModel {
 
   getAssignedEntry(): [string, any] | null {
     const name = this.fieldPath;
-    if (!name) return null;
+    if (!name || !this.collectionField) return null;
     return [name, this.assignValue];
   }
 
   render() {
+    if (!this.collectionField) {
+      return <FieldDeletePlaceholder />;
+    }
+
     // 与 FormItemModel.render 结构保持一致，仅替换内部渲染为 VariableInput + 常量编辑器
     const ctx: any = this.context;
     const collection = ctx.collection;
@@ -392,7 +403,7 @@ AssignFormItemModel.registerFlow({
       },
       defaultParams: (ctx) => {
         return {
-          label: (ctx.model as any).collectionField.title,
+          label: (ctx.model as any).collectionField?.title || (ctx.model as any).fieldPath,
         };
       },
       handler(ctx, params) {

--- a/packages/core/client-v2/src/flow/models/blocks/assign-form/__tests__/assignFieldValuesFlow.editor.test.tsx
+++ b/packages/core/client-v2/src/flow/models/blocks/assign-form/__tests__/assignFieldValuesFlow.editor.test.tsx
@@ -47,7 +47,7 @@ class MockFlowModelRepository implements IFlowModelRepository {
 }
 
 describe('assignFieldValuesFlow (editor)', () => {
-  it('keeps the field selector available when a previously assigned field has been deleted', async () => {
+  it('shows the deleted-field placeholder for a stale assigned value', async () => {
     const engine = new FlowEngine();
     engine.setModelRepository(new MockFlowModelRepository());
     engine.registerModels({
@@ -95,9 +95,95 @@ describe('assignFieldValuesFlow (editor)', () => {
 
     await waitFor(() => {
       expect(screen.getByRole('button', { name: /Fields/ })).toBeInTheDocument();
+      expect(screen.getByText(/deletedField.*may have been deleted/)).toBeInTheDocument();
       const form = engine.findModelByParentId<AssignFormModel>(action.uid, 'assignForm');
       expect(form).toBeDefined();
-      expect(form?.subModels.grid.subModels.items || []).toHaveLength(0);
+      expect(form?.subModels.grid.subModels.items || []).toHaveLength(1);
+      expect(form?.getAssignedValues()).toEqual({});
+    });
+  });
+
+  it('shows the standard deleted-field placeholder for a persisted assigned field model', async () => {
+    const engine = new FlowEngine();
+    engine.setModelRepository(new MockFlowModelRepository());
+    engine.registerModels({
+      AssignFormModel,
+      AssignFormGridModel,
+      AssignFormItemModel,
+      InputFieldModel,
+      VariableFieldFormModel,
+    });
+    engine.context.defineProperty('location', { value: { search: '' } });
+    engine.context.defineProperty('themeToken', { value: { marginLG: 24 } });
+    engine.context.defineProperty('flowSettingsEnabled', { value: true });
+
+    const main = engine.context.dataSourceManager.getDataSource('main');
+    main.addCollection({
+      name: 'users',
+      fields: [{ name: 'nickname', type: 'string', interface: 'input' }],
+    });
+    const users = engine.context.dataSourceManager.getCollection('main', 'users');
+
+    const action = engine.createModel({
+      use: 'FlowModel',
+      uid: 'act-assign-persisted-deleted-field',
+    });
+    action.setStepParams('assignSettings', 'assignFieldValues', {
+      assignedValues: { deletedField: 'stale value' },
+    });
+    action.context.defineProperty('blockModel', { value: { collection: users } });
+
+    const form = engine.createModel<AssignFormModel>({
+      use: 'AssignFormModel',
+      uid: 'form-assign-persisted-deleted-field',
+      parentId: action.uid,
+      subKey: 'assignForm',
+      stepParams: {
+        resourceSettings: {
+          init: {
+            dataSourceKey: 'main',
+            collectionName: 'users',
+          },
+        },
+      },
+    });
+    action.setSubModel('assignForm', form);
+    form.subModels.grid.addSubModel('items', {
+      use: 'AssignFormItemModel',
+      uid: 'item-assign-persisted-deleted-field',
+      stepParams: {
+        fieldSettings: {
+          init: {
+            dataSourceKey: 'main',
+            collectionName: 'users',
+            fieldPath: 'deletedField',
+          },
+          assignValue: { value: 'stale value' },
+        },
+      },
+    });
+    form.subModels.grid.resetRows(true);
+
+    const step = createAssignFieldValuesStep({ settingsFlowKey: 'assignSettings' });
+    const Editor = step.uiSchema().editor?.['x-component'] as React.ComponentType;
+    const flowSettingsCtx = new FlowRuntimeContext(action, 'assignSettings', 'settings');
+
+    render(
+      <FlowEngineProvider engine={engine}>
+        <ConfigProvider>
+          <App>
+            <FlowSettingsContextProvider value={flowSettingsCtx}>
+              <Editor />
+            </FlowSettingsContextProvider>
+          </App>
+        </ConfigProvider>
+      </FlowEngineProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/deletedField.*may have been deleted/)).toBeInTheDocument();
+      expect(form.subModels.grid.subModels.items).toHaveLength(1);
+      expect(form.getAssignedValues()).toEqual({});
     });
   });
 


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
V2 update-record field assignments should keep historical configuration visible when the underlying collection field has been deleted, using the same deleted-field warning as configured form fields.

### Description
- Recreate a placeholder assignment item when legacy `assignedValues` references a deleted field.
- Reuse the standard `FieldDeletePlaceholder` rendering for deleted assignment fields.
- Keep the assignment model available for manual removal while excluding deleted fields from generated update parameters.
- Scope is limited to the V2 assign-form models; there are no database, API, migration, or permission changes.

Verification:
- `yarn test packages/core/client-v2/src/flow/models/blocks/assign-form/__tests__/assignFieldValuesFlow.editor.test.tsx --run --reporter=dot` (4 passed)
- `yarn test packages/core/client-v2/src/flow/models/actions/__tests__/AssignFormRefill.test.ts --run --reporter=dot` (6 passed)
- `yarn eslint --fix` on all touched files
- `git diff --check`

Review focus:
- Deleted fields remain visible with the standard warning and can still be removed manually.
- Deleted fields are not submitted in update parameters.
- Valid field assignments and refill behavior remain unchanged.

### Related issues
- task-6281

### Showcase
- Not included; please verify by deleting a configured field and reopening the V2 update-record action settings.

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Show the standard deleted-field warning for historical V2 field assignments. |
| 🇨🇳 Chinese | V2 历史字段赋值配置中的已删除字段展示统一的删除提示。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | 不需要 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary