### PR TITLE
fix(server): handle unavailable subapp environments

### DIFF
--- a/packages/core/server/src/__tests__/app-supervisor/environment-heartbeat.test.ts
+++ b/packages/core/server/src/__tests__/app-supervisor/environment-heartbeat.test.ts
@@ -95,25 +95,24 @@ describe('environment heartbeat lifecycle', () => {
     expect(log).toHaveBeenCalledWith(error.message, { method: 'heartbeatEnvironment' });
   });
 
-  it.each(['reset', 'unregisterEnvironment'] as const)('waits for an in-flight heartbeat before %s', async (method) => {
-    let finish: () => void = () => {};
-    heartbeat.mockImplementation(
-      () =>
-        new Promise<void>((resolve) => {
-          finish = resolve;
-        }),
-    );
-    await supervisor.heartbeatEnvironment(mainApp);
-    await vi.advanceTimersByTimeAsync(4 * 60 * 1000);
-    expect(heartbeat).toHaveBeenCalledTimes(1);
-    const stopping = supervisor[method]();
-    await Promise.resolve();
-    expect(dispose).not.toHaveBeenCalled();
-    expect(unregister).not.toHaveBeenCalled();
-    finish();
-    await stopping;
-    await vi.advanceTimersByTimeAsync(6 * 60 * 1000);
-    expect(heartbeat).toHaveBeenCalledTimes(1);
-    expect(method === 'reset' ? dispose : unregister).toHaveBeenCalledTimes(1);
-  });
+  it.each(['reset', 'unregisterEnvironment'] as const)(
+    'stops future heartbeats without waiting during %s',
+    async (method) => {
+      let finish: () => void = () => {};
+      heartbeat.mockImplementation(
+        () =>
+          new Promise<void>((resolve) => {
+            finish = resolve;
+          }),
+      );
+      await supervisor.heartbeatEnvironment(mainApp);
+      await vi.advanceTimersByTimeAsync(2 * 60 * 1000);
+      expect(heartbeat).toHaveBeenCalledTimes(1);
+      await supervisor[method]();
+      await vi.advanceTimersByTimeAsync(6 * 60 * 1000);
+      expect(heartbeat).toHaveBeenCalledTimes(1);
+      expect(method === 'reset' ? dispose : unregister).toHaveBeenCalledTimes(1);
+      finish();
+    },
+  );
 });

--- a/packages/core/server/src/__tests__/app-supervisor/environment-heartbeat.test.ts
+++ b/packages/core/server/src/__tests__/app-supervisor/environment-heartbeat.test.ts
@@ -9,9 +9,11 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { AppSupervisor } from '../../app-supervisor';
+import Application from '../../application';
 
 describe('environment heartbeat lifecycle', () => {
   let supervisor: AppSupervisor;
+  const mainApp = { getPackageVersion: () => '2.0.0' } as Application;
   const heartbeat = vi.fn<[], Promise<void>>();
   const unregister = vi.fn();
   const dispose = vi.fn();
@@ -44,16 +46,39 @@ describe('environment heartbeat lifecycle', () => {
     expect(await supervisor.getEnvironment('web')).toMatchObject({ available: false });
   });
 
+  it('passes fresh complete environment information for registration and heartbeat', async () => {
+    const adapter = supervisor.getDiscoveryAdapter();
+    const register = vi.fn().mockResolvedValue(true);
+    Object.assign(adapter, { registerEnvironment: register, environmentUrl: 'https://old.example' });
+    await supervisor.registerEnvironment(mainApp);
+    expect(register).toHaveBeenCalledWith({
+      name: 'web',
+      url: 'https://old.example',
+      proxyUrl: 'https://old.example',
+      appVersion: '2.0.0',
+      lastHeartbeatAt: Date.now(),
+    });
+    Object.assign(adapter, { environmentUrl: 'https://new.example' });
+    await vi.advanceTimersByTimeAsync(2 * 60 * 1000);
+    expect(heartbeat).toHaveBeenCalledWith({
+      name: 'web',
+      url: 'https://new.example',
+      proxyUrl: 'https://new.example',
+      appVersion: '2.0.0',
+      lastHeartbeatAt: Date.now(),
+    });
+  });
+
   it('stops the timer on unregister and allows registration to restart it', async () => {
-    await supervisor.heartbeatEnvironment();
-    await supervisor.heartbeatEnvironment();
+    await supervisor.heartbeatEnvironment(mainApp);
+    await supervisor.heartbeatEnvironment(mainApp);
     await vi.advanceTimersByTimeAsync(2 * 60 * 1000);
     expect(heartbeat).toHaveBeenCalledTimes(1);
     await supervisor.unregisterEnvironment();
     await vi.advanceTimersByTimeAsync(6 * 60 * 1000);
     expect(heartbeat).toHaveBeenCalledTimes(1);
     expect(unregister).toHaveBeenCalledTimes(1);
-    await supervisor.heartbeatEnvironment();
+    await supervisor.heartbeatEnvironment(mainApp);
     await vi.advanceTimersByTimeAsync(2 * 60 * 1000);
     expect(heartbeat).toHaveBeenCalledTimes(2);
   });
@@ -62,7 +87,7 @@ describe('environment heartbeat lifecycle', () => {
     const error = new Error('connection interrupted');
     const log = vi.spyOn(supervisor.logger, 'error').mockImplementation(() => supervisor.logger);
     heartbeat.mockRejectedValueOnce(error);
-    await supervisor.heartbeatEnvironment();
+    await supervisor.heartbeatEnvironment(mainApp);
     await vi.advanceTimersByTimeAsync(4 * 60 * 1000);
     expect(heartbeat).toHaveBeenCalledTimes(2);
     expect(log).toHaveBeenCalledWith(error.message, { method: 'heartbeatEnvironment' });
@@ -76,7 +101,7 @@ describe('environment heartbeat lifecycle', () => {
           finish = resolve;
         }),
     );
-    await supervisor.heartbeatEnvironment();
+    await supervisor.heartbeatEnvironment(mainApp);
     await vi.advanceTimersByTimeAsync(4 * 60 * 1000);
     expect(heartbeat).toHaveBeenCalledTimes(1);
     const stopping = supervisor[method]();

--- a/packages/core/server/src/__tests__/app-supervisor/environment-heartbeat.test.ts
+++ b/packages/core/server/src/__tests__/app-supervisor/environment-heartbeat.test.ts
@@ -1,0 +1,92 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { AppSupervisor } from '../../app-supervisor';
+
+describe('environment heartbeat lifecycle', () => {
+  let supervisor: AppSupervisor;
+  const heartbeat = vi.fn<[], Promise<void>>();
+  const unregister = vi.fn();
+  const dispose = vi.fn();
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    supervisor = AppSupervisor.getInstance();
+    heartbeat.mockReset().mockResolvedValue(undefined);
+    unregister.mockReset();
+    dispose.mockReset();
+    Object.assign(supervisor.getDiscoveryAdapter(), {
+      environmentName: 'web',
+      heartbeatEnvironment: heartbeat,
+      unregisterEnvironment: unregister,
+      dispose,
+      getEnvironment: vi.fn().mockResolvedValue({ name: 'web', lastHeartbeatAt: Date.now() }),
+    });
+  });
+
+  afterEach(async () => {
+    await supervisor.destroy();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('tolerates missed heartbeats for six minutes', async () => {
+    await vi.advanceTimersByTimeAsync(2 * 60 * 1000 + 1);
+    expect(await supervisor.getEnvironment('web')).toMatchObject({ available: true });
+    await vi.advanceTimersByTimeAsync(4 * 60 * 1000);
+    expect(await supervisor.getEnvironment('web')).toMatchObject({ available: false });
+  });
+
+  it('stops the timer on unregister and allows registration to restart it', async () => {
+    await supervisor.heartbeatEnvironment();
+    await supervisor.heartbeatEnvironment();
+    await vi.advanceTimersByTimeAsync(2 * 60 * 1000);
+    expect(heartbeat).toHaveBeenCalledTimes(1);
+    await supervisor.unregisterEnvironment();
+    await vi.advanceTimersByTimeAsync(6 * 60 * 1000);
+    expect(heartbeat).toHaveBeenCalledTimes(1);
+    expect(unregister).toHaveBeenCalledTimes(1);
+    await supervisor.heartbeatEnvironment();
+    await vi.advanceTimersByTimeAsync(2 * 60 * 1000);
+    expect(heartbeat).toHaveBeenCalledTimes(2);
+  });
+
+  it('retries on the next tick after a failed heartbeat', async () => {
+    const error = new Error('connection interrupted');
+    const log = vi.spyOn(supervisor.logger, 'error').mockImplementation(() => supervisor.logger);
+    heartbeat.mockRejectedValueOnce(error);
+    await supervisor.heartbeatEnvironment();
+    await vi.advanceTimersByTimeAsync(4 * 60 * 1000);
+    expect(heartbeat).toHaveBeenCalledTimes(2);
+    expect(log).toHaveBeenCalledWith(error.message, { method: 'heartbeatEnvironment' });
+  });
+
+  it.each(['reset', 'unregisterEnvironment'] as const)('waits for an in-flight heartbeat before %s', async (method) => {
+    let finish: () => void = () => {};
+    heartbeat.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          finish = resolve;
+        }),
+    );
+    await supervisor.heartbeatEnvironment();
+    await vi.advanceTimersByTimeAsync(4 * 60 * 1000);
+    expect(heartbeat).toHaveBeenCalledTimes(1);
+    const stopping = supervisor[method]();
+    await Promise.resolve();
+    expect(dispose).not.toHaveBeenCalled();
+    expect(unregister).not.toHaveBeenCalled();
+    finish();
+    await stopping;
+    await vi.advanceTimersByTimeAsync(6 * 60 * 1000);
+    expect(heartbeat).toHaveBeenCalledTimes(1);
+    expect(method === 'reset' ? dispose : unregister).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/core/server/src/__tests__/app-supervisor/environment-heartbeat.test.ts
+++ b/packages/core/server/src/__tests__/app-supervisor/environment-heartbeat.test.ts
@@ -39,11 +39,13 @@ describe('environment heartbeat lifecycle', () => {
     vi.restoreAllMocks();
   });
 
-  it('tolerates missed heartbeats for six minutes', async () => {
-    await vi.advanceTimersByTimeAsync(2 * 60 * 1000 + 1);
-    expect(await supervisor.getEnvironment('web')).toMatchObject({ available: true });
+  it('marks retained environments offline after five minutes without a heartbeat', async () => {
     await vi.advanceTimersByTimeAsync(4 * 60 * 1000);
-    expect(await supervisor.getEnvironment('web')).toMatchObject({ available: false });
+    expect(await supervisor.getEnvironment('web')).toMatchObject({ available: true });
+    await vi.advanceTimersByTimeAsync(60 * 1000);
+    expect(await supervisor.getEnvironment('web')).toMatchObject({ available: true });
+    await vi.advanceTimersByTimeAsync(1);
+    expect(await supervisor.getEnvironment('web')).toMatchObject({ name: 'web', available: false });
   });
 
   it('passes fresh complete environment information for registration and heartbeat', async () => {

--- a/packages/core/server/src/__tests__/gateway/remote-environment.test.ts
+++ b/packages/core/server/src/__tests__/gateway/remote-environment.test.ts
@@ -1,0 +1,40 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { IncomingMessage, ServerResponse } from 'http';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { AppSupervisor } from '../../app-supervisor';
+import { Gateway } from '../../gateway';
+
+describe('unavailable remote environment', () => {
+  afterEach(async () => {
+    await Gateway.getInstance().destroy();
+    await AppSupervisor.getInstance().destroy();
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+  });
+
+  it.each([true, false])('does not bootstrap locally when the model exists: %s', async (exists) => {
+    vi.stubEnv('APP_MODE', 'supervisor');
+    const supervisor = AppSupervisor.getInstance();
+    Object.assign(supervisor.getDiscoveryAdapter(), { proxyWeb: vi.fn().mockResolvedValue(false) });
+    vi.spyOn(supervisor, 'getAppModel').mockResolvedValue(exists ? { name: 'demo' } : null);
+    const bootstrap = vi.spyOn(supervisor, 'bootstrapApp');
+    const req = { url: '/api/__app/demo/test', headers: {} } as IncomingMessage;
+    const end = vi.fn();
+    const res = { setHeader: vi.fn(), end } as unknown as ServerResponse;
+    await Gateway.getInstance().requestHandler(req, res);
+    expect(bootstrap).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(exists ? 503 : 404);
+    expect(JSON.parse(end.mock.calls[0][0]).error).toMatchObject({
+      code: exists ? 'APP_ENVIRONMENT_UNAVAILABLE' : 'APP_NOT_FOUND',
+      ...(exists ? { message: 'deployment environment for application demo is unavailable' } : {}),
+    });
+  });
+});

--- a/packages/core/server/src/__tests__/gateway/remote-environment.test.ts
+++ b/packages/core/server/src/__tests__/gateway/remote-environment.test.ts
@@ -23,7 +23,10 @@ describe('unavailable remote environment', () => {
   it.each([true, false])('does not bootstrap locally when the model exists: %s', async (exists) => {
     vi.stubEnv('APP_MODE', 'supervisor');
     const supervisor = AppSupervisor.getInstance();
-    Object.assign(supervisor.getDiscoveryAdapter(), { proxyWeb: vi.fn().mockResolvedValue(false) });
+    Object.assign(supervisor.getDiscoveryAdapter(), {
+      proxyWeb: vi.fn().mockResolvedValue(false),
+      getAppModel: vi.fn(),
+    });
     vi.spyOn(supervisor, 'getAppModel').mockResolvedValue(exists ? { name: 'demo' } : null);
     const bootstrap = vi.spyOn(supervisor, 'bootstrapApp');
     const req = { url: '/api/__app/demo/test', headers: {} } as IncomingMessage;
@@ -36,5 +39,37 @@ describe('unavailable remote environment', () => {
       code: exists ? 'APP_ENVIRONMENT_UNAVAILABLE' : 'APP_NOT_FOUND',
       ...(exists ? { message: 'deployment environment for application demo is unavailable' } : {}),
     });
+  });
+
+  it('returns 503 without querying models when the adapter cannot look them up', async () => {
+    vi.stubEnv('APP_MODE', 'supervisor');
+    const supervisor = AppSupervisor.getInstance();
+    Object.assign(supervisor.getDiscoveryAdapter(), {
+      proxyWeb: vi.fn().mockResolvedValue(false),
+      getAppModel: undefined,
+    });
+    const getAppModel = vi.spyOn(supervisor, 'getAppModel');
+    const bootstrap = vi.spyOn(supervisor, 'bootstrapApp');
+    const req = { url: '/api/__app/demo/test', headers: {} } as IncomingMessage;
+    const end = vi.fn();
+    const res = { setHeader: vi.fn(), end } as unknown as ServerResponse;
+    await Gateway.getInstance().requestHandler(req, res);
+    expect(getAppModel).not.toHaveBeenCalled();
+    expect(bootstrap).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(503);
+    expect(JSON.parse(end.mock.calls[0][0]).error.code).toBe('APP_ENVIRONMENT_UNAVAILABLE');
+  });
+
+  it('does not query models or write a fallback response after successful proxying', async () => {
+    vi.stubEnv('APP_MODE', 'supervisor');
+    const supervisor = AppSupervisor.getInstance();
+    Object.assign(supervisor.getDiscoveryAdapter(), { proxyWeb: vi.fn().mockResolvedValue(true) });
+    const getAppModel = vi.spyOn(supervisor, 'getAppModel');
+    const req = { url: '/api/__app/demo/test', headers: {} } as IncomingMessage;
+    const end = vi.fn();
+    const res = { setHeader: vi.fn(), end } as unknown as ServerResponse;
+    await Gateway.getInstance().requestHandler(req, res);
+    expect(getAppModel).not.toHaveBeenCalled();
+    expect(end).not.toHaveBeenCalled();
   });
 });

--- a/packages/core/server/src/app-supervisor/index.ts
+++ b/packages/core/server/src/app-supervisor/index.ts
@@ -80,6 +80,7 @@ export class AppSupervisor extends EventEmitter implements AsyncEmitter {
   public appOptionsFactory: AppOptionsFactory = appOptionsFactory;
 
   private environmentHeartbeatInterval = 2 * 60 * 1000;
+  private environmentHeartbeatTimeout = 5 * 60 * 1000;
   private environmentHeartbeatTimer = null;
   private environmentHeartbeatTask?: Promise<void>;
 
@@ -776,7 +777,7 @@ export class AppSupervisor extends EventEmitter implements AsyncEmitter {
         available: false,
       };
     }
-    const available = Date.now() - lastHeartbeatAt <= this.environmentHeartbeatInterval * 3;
+    const available = Date.now() - lastHeartbeatAt <= this.environmentHeartbeatTimeout;
     return {
       ...environment,
       available,

--- a/packages/core/server/src/app-supervisor/index.ts
+++ b/packages/core/server/src/app-supervisor/index.ts
@@ -82,7 +82,6 @@ export class AppSupervisor extends EventEmitter implements AsyncEmitter {
   private environmentHeartbeatInterval = 2 * 60 * 1000;
   private environmentHeartbeatTimeout = 5 * 60 * 1000;
   private environmentHeartbeatTimer = null;
-  private environmentHeartbeatTask?: Promise<void>;
 
   private constructor() {
     super();
@@ -364,7 +363,7 @@ export class AppSupervisor extends EventEmitter implements AsyncEmitter {
   }
 
   async reset() {
-    await this.stopEnvironmentHeartbeat();
+    this.stopEnvironmentHeartbeat();
     await this.processAdapter.removeAllApps();
     await this.discoveryAdapter.dispose?.();
     await this.commandAdapter?.dispose?.();
@@ -760,7 +759,7 @@ export class AppSupervisor extends EventEmitter implements AsyncEmitter {
   }
 
   async unregisterEnvironment() {
-    await this.stopEnvironmentHeartbeat();
+    this.stopEnvironmentHeartbeat();
     if (this.environmentName && typeof this.discoveryAdapter.unregisterEnvironment === 'function') {
       await this.discoveryAdapter.unregisterEnvironment();
     }
@@ -812,27 +811,20 @@ export class AppSupervisor extends EventEmitter implements AsyncEmitter {
     if (this.environmentHeartbeatTimer) {
       return;
     }
-    this.environmentHeartbeatTimer = setInterval(() => {
-      if (this.environmentHeartbeatTask) {
-        return;
+    this.environmentHeartbeatTimer = setInterval(async () => {
+      try {
+        await this.discoveryAdapter.heartbeatEnvironment(this.getEnvironmentInfo(mainApp));
+      } catch (error: unknown) {
+        this.logger.error(error instanceof Error ? error.message : String(error), { method: 'heartbeatEnvironment' });
       }
-      this.environmentHeartbeatTask = Promise.resolve()
-        .then(() => this.discoveryAdapter.heartbeatEnvironment(this.getEnvironmentInfo(mainApp)))
-        .catch((error: unknown) => {
-          this.logger.error(error instanceof Error ? error.message : String(error), { method: 'heartbeatEnvironment' });
-        })
-        .finally(() => {
-          this.environmentHeartbeatTask = undefined;
-        });
     }, this.environmentHeartbeatInterval);
   }
 
-  private async stopEnvironmentHeartbeat() {
+  private stopEnvironmentHeartbeat() {
     if (this.environmentHeartbeatTimer) {
       clearInterval(this.environmentHeartbeatTimer);
       this.environmentHeartbeatTimer = null;
     }
-    await this.environmentHeartbeatTask;
   }
 
   async dispatchCommand(command: ProcessCommand) {

--- a/packages/core/server/src/app-supervisor/index.ts
+++ b/packages/core/server/src/app-supervisor/index.ts
@@ -81,6 +81,7 @@ export class AppSupervisor extends EventEmitter implements AsyncEmitter {
 
   private environmentHeartbeatInterval = 2 * 60 * 1000;
   private environmentHeartbeatTimer = null;
+  private environmentHeartbeatTask?: Promise<void>;
 
   private constructor() {
     super();
@@ -362,13 +363,11 @@ export class AppSupervisor extends EventEmitter implements AsyncEmitter {
   }
 
   async reset() {
+    await this.stopEnvironmentHeartbeat();
     await this.processAdapter.removeAllApps();
     await this.discoveryAdapter.dispose?.();
     await this.commandAdapter?.dispose?.();
     this.appManifests.clear();
-    if (this.environmentHeartbeatTimer) {
-      this.environmentHeartbeatTimer = null;
-    }
     this.removeAllListeners();
     this.logger.close();
   }
@@ -756,11 +755,9 @@ export class AppSupervisor extends EventEmitter implements AsyncEmitter {
   }
 
   async unregisterEnvironment() {
+    await this.stopEnvironmentHeartbeat();
     if (this.environmentName && typeof this.discoveryAdapter.unregisterEnvironment === 'function') {
       await this.discoveryAdapter.unregisterEnvironment();
-    }
-    if (this.environmentHeartbeatTimer) {
-      this.environmentHeartbeatTimer = null;
     }
   }
 
@@ -775,7 +772,7 @@ export class AppSupervisor extends EventEmitter implements AsyncEmitter {
         available: false,
       };
     }
-    const available = Date.now() - lastHeartbeatAt <= this.environmentHeartbeatInterval;
+    const available = Date.now() - lastHeartbeatAt <= this.environmentHeartbeatInterval * 3;
     return {
       ...environment,
       available,
@@ -810,10 +807,27 @@ export class AppSupervisor extends EventEmitter implements AsyncEmitter {
     if (this.environmentHeartbeatTimer) {
       return;
     }
-    this.environmentHeartbeatTimer = setInterval(
-      () => this.discoveryAdapter.heartbeatEnvironment(),
-      this.environmentHeartbeatInterval,
-    );
+    this.environmentHeartbeatTimer = setInterval(() => {
+      if (this.environmentHeartbeatTask) {
+        return;
+      }
+      this.environmentHeartbeatTask = Promise.resolve()
+        .then(() => this.discoveryAdapter.heartbeatEnvironment())
+        .catch((error: unknown) => {
+          this.logger.error(error instanceof Error ? error.message : String(error), { method: 'heartbeatEnvironment' });
+        })
+        .finally(() => {
+          this.environmentHeartbeatTask = undefined;
+        });
+    }, this.environmentHeartbeatInterval);
+  }
+
+  private async stopEnvironmentHeartbeat() {
+    if (this.environmentHeartbeatTimer) {
+      clearInterval(this.environmentHeartbeatTimer);
+      this.environmentHeartbeatTimer = null;
+    }
+    await this.environmentHeartbeatTask;
   }
 
   async dispatchCommand(command: ProcessCommand) {

--- a/packages/core/server/src/app-supervisor/index.ts
+++ b/packages/core/server/src/app-supervisor/index.ts
@@ -742,16 +742,20 @@ export class AppSupervisor extends EventEmitter implements AsyncEmitter {
     if (!this.environmentName || typeof this.discoveryAdapter.registerEnvironment !== 'function') {
       return;
     }
-    const registered = await this.discoveryAdapter.registerEnvironment({
+    const registered = await this.discoveryAdapter.registerEnvironment(this.getEnvironmentInfo(mainApp));
+    if (registered) {
+      this.heartbeatEnvironment(mainApp);
+    }
+  }
+
+  private getEnvironmentInfo(mainApp: Application): EnvironmentInfo {
+    return {
       name: this.environmentName,
       url: this.environmentUrl || '',
       proxyUrl: this.environmentProxyUrl || this.environmentUrl || '',
       appVersion: mainApp.getPackageVersion(),
       lastHeartbeatAt: Date.now(),
-    });
-    if (registered) {
-      this.heartbeatEnvironment();
-    }
+    };
   }
 
   async unregisterEnvironment() {
@@ -800,7 +804,7 @@ export class AppSupervisor extends EventEmitter implements AsyncEmitter {
     return this.normalizeEnvInfo(environment);
   }
 
-  async heartbeatEnvironment() {
+  async heartbeatEnvironment(mainApp: Application) {
     if (typeof this.discoveryAdapter.heartbeatEnvironment !== 'function') {
       return;
     }
@@ -812,7 +816,7 @@ export class AppSupervisor extends EventEmitter implements AsyncEmitter {
         return;
       }
       this.environmentHeartbeatTask = Promise.resolve()
-        .then(() => this.discoveryAdapter.heartbeatEnvironment())
+        .then(() => this.discoveryAdapter.heartbeatEnvironment(this.getEnvironmentInfo(mainApp)))
         .catch((error: unknown) => {
           this.logger.error(error instanceof Error ? error.message : String(error), { method: 'heartbeatEnvironment' });
         })

--- a/packages/core/server/src/app-supervisor/types.ts
+++ b/packages/core/server/src/app-supervisor/types.ts
@@ -163,7 +163,7 @@ export interface AppDiscoveryAdapter {
   unregisterEnvironment?(): Promise<void>;
   listEnvironments?(): Promise<EnvironmentInfo[]>;
   getEnvironment?(environmentName: string): Promise<EnvironmentInfo | null>;
-  heartbeatEnvironment?(): Promise<void>;
+  heartbeatEnvironment?(environment: EnvironmentInfo): Promise<void>;
   getBootstrapLock?(appName: string): Promise<BootstrapLock | null> | BootstrapLock | null;
 
   proxyWeb?(appName: string, req: IncomingMessage, res: ServerResponse): Promise<boolean>;

--- a/packages/core/server/src/gateway/errors.ts
+++ b/packages/core/server/src/gateway/errors.ts
@@ -34,6 +34,11 @@ function getAppName(app: Application) {
 }
 
 export const errors: AppErrors = {
+  APP_ENVIRONMENT_UNAVAILABLE: {
+    status: 503,
+    message: ({ appName }) => `deployment environment for application ${appName} is unavailable`,
+    maintaining: true,
+  },
   APP_NOT_FOUND: {
     status: 404,
     message: ({ appName }) => `application ${appName} not found`,

--- a/packages/core/server/src/gateway/index.ts
+++ b/packages/core/server/src/gateway/index.ts
@@ -137,11 +137,13 @@ export class Gateway extends EventEmitter {
     req.url = this.getOriginalRequestUrl(req);
     try {
       const proxied = await supervisor.proxyWeb(appName, req, res);
-      if (!proxied && process.env.APP_MODE === 'supervisor' && supervisor.getDiscoveryAdapter().proxyWeb) {
-        const appModel = await supervisor.getAppModel(appName);
-        this.responseErrorWithCode(appModel ? 'APP_ENVIRONMENT_UNAVAILABLE' : 'APP_NOT_FOUND', res, {
-          appName,
-        });
+      const adapter = supervisor.getDiscoveryAdapter();
+      if (!proxied && process.env.APP_MODE === 'supervisor' && typeof adapter.proxyWeb === 'function') {
+        let code = 'APP_ENVIRONMENT_UNAVAILABLE';
+        if (typeof adapter.getAppModel === 'function' && !(await supervisor.getAppModel(appName))) {
+          code = 'APP_NOT_FOUND';
+        }
+        this.responseErrorWithCode(code, res, { appName });
         return true;
       }
       return proxied;

--- a/packages/core/server/src/gateway/index.ts
+++ b/packages/core/server/src/gateway/index.ts
@@ -136,7 +136,15 @@ export class Gateway extends EventEmitter {
     const internalUrl = req.url;
     req.url = this.getOriginalRequestUrl(req);
     try {
-      return await supervisor.proxyWeb(appName, req, res);
+      const proxied = await supervisor.proxyWeb(appName, req, res);
+      if (!proxied && process.env.APP_MODE === 'supervisor' && supervisor.getDiscoveryAdapter().proxyWeb) {
+        const appModel = await supervisor.getAppModel(appName);
+        this.responseErrorWithCode(appModel ? 'APP_ENVIRONMENT_UNAVAILABLE' : 'APP_NOT_FOUND', res, {
+          appName,
+        });
+        return true;
+      }
+      return proxied;
     } finally {
       req.url = internalUrl;
     }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution!
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch.
Thank you!
-->

### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Remote subapps can remain on the preparing screen when their deployment environment cannot be resolved, even though a worker is running. Environment heartbeat timers also survive teardown.

### Description

- Stop heartbeat timers and await in-flight heartbeats before unregister/reset; prevent overlapping heartbeats and handle failures
- Allow three heartbeat intervals (six minutes) before marking an environment unavailable
- Return APP_ENVIRONMENT_UNAVAILABLE (503) for unresolved remote targets instead of falling back to local bootstrap; retain 404 for unknown apps
- Companion plugin changes use the same branch in nocobase/plugin-app-supervisor and preserve shared registrations during rolling replacement

Deployment requires the companion plugin change. Replicas in one environment must share a stable Service/load-balancer URL. The last replica's exit is detected after heartbeat expiry, not immediately.

Verification: environment-heartbeat (5), remote-environment gateway (2), and boot-main-app (9) tests passed; ESLint and diff checks passed. The full gateway integration suite could not complete because the local PostgreSQL connection failed, including outside the sandbox.

### Related issues

Multi-environment subapps incorrectly remaining on the preparing screen

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed misleading preparing status when a subapp deployment environment is unavailable |
| 🇨🇳 Chinese | 修复子应用部署环境不可用时错误显示准备中的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [ ] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
