### PR TITLE
fix(sdk): clear a rejected role in the shared API client so the v2 shell can recover

### DIFF
--- a/packages/core/client-v2/src/__tests__/APIClient.test.tsx
+++ b/packages/core/client-v2/src/__tests__/APIClient.test.tsx
@@ -56,3 +56,40 @@ describe('APIClient response notifications', () => {
     expect(renderToStaticMarkup(<>{message}</>)).toContain('Created successfully');
   });
 });
+
+describe('APIClient rejected role', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('forgets a role the server no longer accepts and reloads', async () => {
+    const { apiClient, apiMock, notification } = createAPIClient();
+    const reload = vi.spyOn(APIClient.prototype as any, 'reload').mockImplementation(() => undefined);
+    apiClient.app = { ...apiClient.app, eventBus: new EventTarget() } as any;
+    apiClient.auth.setToken('123');
+    apiClient.auth.setRole('stale');
+    apiMock.onGet('/auth:check').reply(401, {
+      errors: [{ code: 'ROLE_NOT_FOUND_FOR_USER', message: 'The role does not belong to the user' }],
+    });
+
+    // Same options as the `auth:check` request issued by the built-in plugin on every page load.
+    await expect(apiClient.request({ url: '/auth:check', skipNotify: true, skipAuth: true })).rejects.toBeDefined();
+
+    expect(apiClient.auth.role).toBeFalsy();
+    expect(apiClient.auth.token).toBe('123');
+    expect(reload).toHaveBeenCalledOnce();
+    expect(notification.error).not.toHaveBeenCalled();
+  });
+
+  it('keeps the role on other 401 errors', async () => {
+    const { apiClient, apiMock } = createAPIClient();
+    const reload = vi.spyOn(APIClient.prototype as any, 'reload').mockImplementation(() => undefined);
+    apiClient.auth.setRole('admin');
+    apiMock.onGet('/auth:check').reply(401, { errors: [{ message: 'Unauthenticated' }] });
+
+    await expect(apiClient.request({ url: '/auth:check', skipNotify: true, skipAuth: true })).rejects.toBeDefined();
+
+    expect(apiClient.auth.role).toBe('admin');
+    expect(reload).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/client-v2/src/nocobase-buildin-plugin/index.tsx
+++ b/packages/core/client-v2/src/nocobase-buildin-plugin/index.tsx
@@ -8,6 +8,7 @@
  */
 
 import { createCollectionContextMeta, useFlowEngine } from '@nocobase/flow-engine';
+import { isRejectedRoleError } from '@nocobase/sdk';
 import React, { createContext, type FC, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { Navigate, Outlet, useLocation, useNavigate } from 'react-router-dom';
 import { useACLRoleContext } from '../acl';
@@ -277,6 +278,12 @@ const CurrentUserProvider: FC = ({ children }) => {
         const isAuthError = errorLike?.response?.status === 401 || errorLike?.status === 401;
         if (isAuthError) {
           setState({ loading: true, authStatus: 'unauthenticated', error: null });
+          // The API client is clearing a rejected role and reloading the page to start over with the
+          // user's default role. Redirecting to sign-in here would race that reload and could strand
+          // the still-authenticated user on the sign-in page, so let the reload take over.
+          if (isRejectedRoleError(error)) {
+            return;
+          }
           navigate(`/signin?redirect=${encodeURIComponent(getCurrentV2RedirectPath(app, locationRef.current))}`, {
             replace: true,
           });

--- a/packages/core/client/src/api-client/APIClient.ts
+++ b/packages/core/client/src/api-client/APIClient.ts
@@ -136,16 +136,8 @@ export class APIClient extends APIClientSDK {
         const errs = this.toErrMessages(error);
         // Hard code here temporarily
         // TODO(yangqia): improve error code and message
-        if (errs.find((error: { code?: string }) => error.code === 'ROLE_NOT_FOUND_ERR')) {
-          this.auth.setRole(null);
-          window.location.reload();
-        }
         if (errs.find((error: { code?: string }) => error.code === 'TOKEN_INVALID' || error.code === 'USER_LOCKED')) {
           this.auth.setToken(null);
-        }
-        if (errs.find((error: { code?: string }) => error.code === 'ROLE_NOT_FOUND_FOR_USER')) {
-          this.auth.setRole(null);
-          window.location.reload();
         }
         throw error;
       },

--- a/packages/core/sdk/src/APIClient.ts
+++ b/packages/core/sdk/src/APIClient.ts
@@ -47,6 +47,20 @@ export type RequestOptions = AxiosRequestConfig & {
   skipAuth?: boolean;
 };
 
+// Error codes with which `setCurrentRole` in `@nocobase/plugin-acl` refuses the role sent in `X-Role`.
+const ROLE_REJECTED_ERROR_CODES = new Set(['ROLE_NOT_FOUND_ERR', 'ROLE_NOT_FOUND_FOR_USER']);
+
+/**
+ * Whether a request failed because the server refused the stored role sent in `X-Role`.
+ *
+ * The API client already reacts to this by clearing the role and reloading; a shell can use this
+ * to avoid, for example, redirecting to the sign-in page and fighting that reload.
+ */
+export function isRejectedRoleError(error: unknown): boolean {
+  const errors = (error as { response?: { data?: { errors?: { code?: string }[] } } })?.response?.data?.errors;
+  return Array.isArray(errors) && errors.some((item) => ROLE_REJECTED_ERROR_CODES.has(item?.code));
+}
+
 export class APIClient {
   options?: APIClientOptions;
   axios: AxiosInstance;
@@ -78,7 +92,7 @@ export class APIClient {
     return (
       error?.response?.data?.errors ||
       error?.response?.data?.messages ||
-      error?.response?.error || [{ message: error.message || 'Server error' }]
+      error?.response?.error || [{ message: error?.message || 'Server error' }]
     );
   }
 
@@ -160,6 +174,36 @@ export class APIClient {
       };
       return config;
     });
+    this.axios.interceptors.response.use(undefined, (error) => this.handleRejectedRole(error));
+  }
+
+  /**
+   * Forgets the stored role right after the server has refused it, so that the next request
+   * does not fail for the same reason.
+   *
+   * Every request carries the stored role as `X-Role`. Once that role stops belonging to the
+   * current user (it was revoked, or the browser signed in to another account), the server
+   * rejects every request with `ROLE_NOT_FOUND_FOR_USER`, including `auth:check`, and signing
+   * in again does not help because the role survives the sign-in. Dropping it and reloading
+   * lets the server fall back to the user's default role.
+   */
+  protected handleRejectedRole(error: unknown) {
+    if (isRejectedRoleError(error)) {
+      this.auth.setRole(null);
+      this.reload();
+    }
+    throw error;
+  }
+
+  /**
+   * Reloads the page so the application boots again with the credentials left in storage.
+   * A no-op outside the browser.
+   */
+  protected reload() {
+    if (typeof window === 'undefined' || typeof window.location?.reload !== 'function') {
+      return;
+    }
+    window.location.reload();
   }
 
   request<T = any, R = AxiosResponse<T>, D = any>(

--- a/packages/core/sdk/src/__tests__/api-client.test.ts
+++ b/packages/core/sdk/src/__tests__/api-client.test.ts
@@ -10,7 +10,7 @@
 import { AxiosResponse } from 'axios';
 import MockAdapter from 'axios-mock-adapter';
 import { getAuthCookieName } from '@nocobase/utils/client';
-import { APIClient } from '../APIClient';
+import { APIClient, isRejectedRoleError } from '../APIClient';
 import { Auth } from '../Auth';
 
 describe('api-client', () => {
@@ -238,5 +238,119 @@ describe('api-client', () => {
     expect(token).toBe('123');
     const auth = localStorage.getItem('NOCOBASE_AUTH');
     expect(auth).toBe('test');
+  });
+
+  describe('isRejectedRoleError', () => {
+    const asError = (code?: string) => ({ response: { data: { errors: code ? [{ code }] : [] } } });
+
+    it('detects both role rejection codes', () => {
+      expect(isRejectedRoleError(asError('ROLE_NOT_FOUND_FOR_USER'))).toBe(true);
+      expect(isRejectedRoleError(asError('ROLE_NOT_FOUND_ERR'))).toBe(true);
+    });
+
+    it('ignores other errors and malformed shapes', () => {
+      expect(isRejectedRoleError(asError('USER_HAS_NO_ROLES_ERR'))).toBe(false);
+      expect(isRejectedRoleError(asError())).toBe(false);
+      expect(isRejectedRoleError(new Error('network error'))).toBe(false);
+      expect(isRejectedRoleError(undefined)).toBe(false);
+    });
+  });
+
+  describe('rejected role', () => {
+    function createClient(options: Record<string, unknown> = {}) {
+      const api = new APIClient({
+        baseURL: 'https://localhost:8000/api',
+        ...options,
+      });
+      const mock = new MockAdapter(api.axios);
+      const reload = vi.fn();
+      (window as any).location.reload = reload;
+      return { api, mock, reload };
+    }
+
+    const rejection = (code: string) => ({
+      errors: [{ code, message: 'The role does not belong to the user' }],
+    });
+
+    test.each(['ROLE_NOT_FOUND_FOR_USER', 'ROLE_NOT_FOUND_ERR'])(
+      'forgets the stored role and reloads on %s',
+      async (code) => {
+        const { api, mock, reload } = createClient();
+        const roleCookie = getAuthCookieName('role', 'main');
+        api.auth.setToken('123');
+        api.auth.setRole('stale');
+        expect(document.cookie).toContain(`${roleCookie}=stale`);
+        mock.onGet('auth:check').reply(401, rejection(code));
+
+        await expect(api.request({ url: 'auth:check' })).rejects.toMatchObject({
+          response: { status: 401 },
+        });
+
+        expect(api.auth.role).toBeFalsy();
+        expect(localStorage.getItem('NOCOBASE_ROLE')).toBeFalsy();
+        expect(document.cookie).not.toContain(`${roleCookie}=`);
+        expect(api.auth.token).toBe('123');
+        expect(reload).toHaveBeenCalledTimes(1);
+      },
+    );
+
+    test('forgets the role stored under the sub app prefix', async () => {
+      const { api, mock, reload } = createClient({ appName: 'myApp' });
+      const roleCookie = getAuthCookieName('role', 'myApp');
+      api.auth.setRole('stale');
+      expect(localStorage.getItem('NOCOBASE_MYAPP_ROLE')).toBe('stale');
+      expect(document.cookie).toContain(`${roleCookie}=stale`);
+      mock.onGet('auth:check').reply(401, rejection('ROLE_NOT_FOUND_FOR_USER'));
+
+      await expect(api.request({ url: 'auth:check' })).rejects.toBeDefined();
+
+      expect(localStorage.getItem('NOCOBASE_MYAPP_ROLE')).toBeFalsy();
+      expect(document.cookie).not.toContain(`${roleCookie}=`);
+      expect(reload).toHaveBeenCalledTimes(1);
+    });
+
+    test('is not suppressed by skipNotify or skipAuth', async () => {
+      const { api, mock, reload } = createClient();
+      api.auth.setRole('stale');
+      mock.onGet('auth:check').reply(401, rejection('ROLE_NOT_FOUND_FOR_USER'));
+
+      await expect(api.request({ url: 'auth:check', skipNotify: true, skipAuth: true })).rejects.toBeDefined();
+
+      expect(api.auth.role).toBeFalsy();
+      expect(reload).toHaveBeenCalledTimes(1);
+    });
+
+    test('keeps the stored credentials on other errors', async () => {
+      const { api, mock, reload } = createClient();
+      api.auth.setToken('123');
+      api.auth.setRole('admin');
+      mock.onGet('users:list').reply(403, { errors: [{ code: 'PERMISSION_DENIED', message: 'Forbidden' }] });
+      mock.onGet('users:get').reply(500, { errors: [{ message: 'Internal Server Error' }] });
+      mock.onGet('auth:check').reply(401, { errors: [{ code: 'USER_HAS_NO_ROLES_ERR', message: 'No roles' }] });
+
+      await expect(api.request({ url: 'users:list' })).rejects.toBeDefined();
+      await expect(api.request({ url: 'users:get' })).rejects.toBeDefined();
+      await expect(api.request({ url: 'auth:check' })).rejects.toBeDefined();
+
+      expect(api.auth.token).toBe('123');
+      expect(api.auth.role).toBe('admin');
+      expect(reload).not.toHaveBeenCalled();
+    });
+
+    test('still forgets the role when the page cannot be reloaded', async () => {
+      // `window` is rebuilt without `location.reload` before each test.
+      const api = new APIClient({
+        baseURL: 'https://localhost:8000/api',
+      });
+      const mock = new MockAdapter(api.axios);
+      api.auth.setRole('stale');
+      mock.onGet('auth:check').reply(401, rejection('ROLE_NOT_FOUND_FOR_USER'));
+
+      await expect(api.request({ url: 'auth:check' })).rejects.toMatchObject({
+        response: { status: 401 },
+      });
+
+      expect(api.auth.role).toBeFalsy();
+    });
   });
 });


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

In the v2 shell (`/v/` routes), a user whose stored role no longer belongs to them **cannot get back into the app**: every page load bounces them to the sign-in page with a `The role does not belong to the user` notification, and signing in again brings them straight back to the same page.

The selected role is kept in `localStorage` (`NOCOBASE_ROLE`) and sent as the `X-Role` header on every request. When that role no longer belongs to the user, `setCurrentRole` in `@nocobase/plugin-acl` rejects **every** request with `401 ROLE_NOT_FOUND_FOR_USER` — it only falls back to the default role silently when the role came from the cookie, not from the header:

```ts
// packages/plugins/@nocobase/plugin-acl/src/server/middlewares/setCurrentRole.ts
role = userRoles.find((role) => role.name === currentRole)?.name;
if (!role) {
  if (currentRoleFromCookie) { /* clears the cookie, falls back to the default role */ }
  else {
    return ctx.throw(401, { code: 'ROLE_NOT_FOUND_FOR_USER', ... });
  }
}
```

That is the intended contract for an explicit header: the **client** is expected to drop the role and start over. The legacy client does exactly that, in `@nocobase/client`'s `APIClient.interceptors()`:

```ts
if (errs.find((error) => error.code === 'ROLE_NOT_FOUND_FOR_USER')) {
  this.auth.setRole(null);
  window.location.reload();
}
```

`@nocobase/client-v2` ships its own `APIClient` with its own `interceptors()` (added in v2.1.12), and this recovery was not carried over. Nothing else in the v2 shell compensates:

- `auth:check` is the first request to fail, and `CurrentUserProvider` reacts to any 401 by navigating to `/signin`.
- `ACLProvider` does clear the role on a failed `roles:check`, but it never runs on this path — the sign-in redirect happens first, and it is skipped on auth routes.
- `Auth.signIn()` stores the new token and authenticator but never touches the role, so the next `auth:check` fails the same way.

How users reach this state in practice:

| Situation | Stored role | Account after the change |
| --- | --- | --- |
| Role revoked or deleted by an admin | the old role | no longer has it |
| One browser used for two accounts (e.g. an SSO account, then a synced DingTalk account) | role chosen on account A | account B never had it |
| Role chosen in the role switcher, later removed from the user | that role | default role only |

**Reproduction** (against a 2.2.5 instance, Chromium, via Playwright): set `localStorage.NOCOBASE_ROLE` to any role the signed-in user does not have and open `/v/admin`. Result: six `401 ROLE_NOT_FOUND_FOR_USER` responses, a redirect to `/v/signin`, and the role still in `localStorage`; signing in again repeats the cycle.

### Description

The recovery is moved down into `@nocobase/sdk`'s `APIClient`, the layer that stores the role and sends it on every request, so both shells (and any other SDK consumer) behave the same way.

**`packages/core/sdk/src/APIClient.ts`**
- `interceptors()` registers a rejection handler, `handleRejectedRole()`, that on `ROLE_NOT_FOUND_FOR_USER` / `ROLE_NOT_FOUND_ERR` clears the role and reloads, then re-throws unchanged so notifications and per-request handling still see the original error.
- `reload()` is a small protected method, a no-op outside the browser, so the client keeps working in Node and in tests.
- `isRejectedRoleError(error)` is exported so a shell can recognise this specific failure (see below). The interceptor uses the same helper, so the two never disagree.

**`packages/core/client-v2/src/nocobase-buildin-plugin/index.tsx`**
- On this failure the API client has already scheduled a reload; `CurrentUserProvider`'s `auth:check` catch would otherwise `navigate('/signin')` and race it. It now returns without redirecting when `isRejectedRoleError(error)` is true, so the reload deterministically wins and the app boots again under the user's default role — instead of the outcome depending on which navigation the browser commits.

**`packages/core/client/src/api-client/APIClient.ts`**
- The two role branches are removed (the SDK now does that work one level down). The `TOKEN_INVALID` / `USER_LOCKED` token branch is left untouched: I could not find a producer of those codes in this repository, so I kept that behaviour exactly where it already was rather than move a code path I cannot exercise.

Risks: low.
- Legacy client: unchanged for role errors, other than the reset now running before the notification middleware instead of after it; I could not find a user-visible difference, but I have not exercised every error shape.
- v2 client: replaces "stuck on the sign-in page" with the legacy outcome — one reload, then the default role.
- **Embedded pages** (`@nocobase/plugin-embed`) register their own `auth:check` interceptor that turns a 401 into an anonymous response. The SDK interceptor is registered first, so an embedded page with a stale role now reloads once (dropping the role) instead of silently rendering as anonymous. After the reload `auth:check` carries no `X-Role`, so it no longer hits this code and there is no loop.

Testing: unit tests only, since the fix is client-side request handling.

- `packages/core/sdk/src/__tests__/api-client.test.ts` — `isRejectedRoleError` matches both codes and rejects other/malformed shapes; a new `rejected role` group asserts that both codes clear the role and its cookie, keep the token and reload once; that the role stored under a sub-app prefix (`appName`) and its namespaced cookie are cleared; that `skipNotify` / `skipAuth` do not suppress the reset; that other 4xx/5xx errors (including `USER_HAS_NO_ROLES_ERR`) touch nothing; and that the role is still cleared when `window.location.reload` is unavailable.
- `packages/core/client-v2/src/__tests__/APIClient.test.tsx` — the v2 `APIClient` forgets a rejected role and reloads on the real `auth:check` options (`skipNotify` + `skipAuth`, asserting no notification is shown); this is the regression test for the bug and fails on `main` (the v2 client has no such handler, so neither the reload nor the reset happens). A second case keeps the role on an unrelated 401.
- `packages/core/client/src/api-client/__tests__/APIClient.test.tsx` — the existing `should reset role when role is not found` case now passes through the SDK handler unchanged.

Manual verification of the v2 flow: sign in on `/v/`, set `localStorage.NOCOBASE_ROLE` to a role the account does not have, reload — expect one reload and the app open under the default role, not the sign-in page.

### Related issues

Adjacent but distinct: #10399 reports a separate defect in the same `setCurrentRole` middleware (under default role mode, `X-Role: __union__` is silently rewritten to the user's first role instead of being refused). This PR does not touch that path — it only handles the client side of the existing `ROLE_NOT_FOUND_FOR_USER` refusal, which the middleware's tests already lock in for an explicit `X-Role` (`setCurrentRole.test.ts` "should throw error"), while a stale role cookie is corrected server-side ("should clear invalid role cookie and fallback to default role").

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the v2 client getting stuck on the sign-in page when the stored role no longer belongs to the user |
| 🇨🇳 Chinese | 修复新版界面在浏览器中残留的角色不再属于当前用户时，反复被退回登录页、无法进入系统的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | |
| 🇨🇳 Chinese | |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary

🤖 Generated with [Claude Code](https://claude.com/claude-code)
