### PR TITLE
fix(data-source-main): remove dbsync incorrectly filtered in syncFieldsFromDatabase

### DIFF
--- a/packages/core/server/src/main-data-source.ts
+++ b/packages/core/server/src/main-data-source.ts
@@ -117,7 +117,7 @@ export class MainDataSource extends SequelizeDataSource {
       },
     });
     const collections = loadedCollections.filter(
-      (collection: Model) => !['db2cm', 'dbsync'].includes(collection.options?.from),
+      (collection: Model) => !['db2cm'].includes(collection.options?.from),
     );
     const loadedData = {};
     for (const collection of collections) {


### PR DESCRIPTION
### 🐛 Bug 描述

当用户通过 **Data Source Manager → "Sync from database" → "Load collection"** 将数据库中已存在的表导入 NocoBase 时，该 Collection 会被标记 `from: 'dbsync'`。然而在使用 **"Sync field changes from database"** 功能同步数据库端直接增删的字段时，`dbsync` 来源的 Collection 实际**无法同步任何字段变更**，API 返回 200 且 UI 提示 "Sync successfully"，但字段列表保持不变（静默失败）。

### 🔍 复现步骤

1. 在数据库中手动建一张测试表：
   ```sql
   CREATE TABLE public.test_dbsync ( id SERIAL PRIMARY KEY, name VARCHAR(100) );
   
2. 进入 NocoBase → **Data Source Manager** → **Main** → **Sync from database** → **Load collection**，将 `test_dbsync` 导入。

3. 在数据库端直接修改表结构：
    ```sql
    ALTER TABLE public.test_dbsync ADD COLUMN new_column TEXT; ALTER TABLE public.test_dbsync DROP COLUMN name;

4. 在 **Collections** 页面找到 `test_dbsync` → Actions → **"Sync from database"**（单表同步）。

5. **期望结果：** Fields 列表应新增 `new_column`，`name` 消失。

**实际结果（修复前）：** Fields 列表保持不变。

### 🎯 原因

`MainDataSource.getLoadedCollections()` 在 `syncFieldsFromDatabase` 的第一步就错误地把 `from: 'dbsync'` 的 Collection 过滤掉了，导致后续的 introspection 读取、字段 diff 比较和 L2 写回事务**全部空转**。

**关键代码位置：**
- 导入打标：`packages/core/server/src/main-data-source.ts` loadTables 中写入 `from: 'dbsync'`
- Bug 所在：`packages/core/server/src/main-data-source.ts` getLoadedCollections() 过滤条件误将 `dbsync` 加入黑名单

**两种 `from` 来源的含义差异：**

| from | 含义 | 是否应参与 syncFields |
|------|------|----------------------|
| `db2cm` | 插件代码内置表（插件启用时自动反写入 CollectionManager），字段由代码定义 | ❌ 正确排除 |
| `dbsync` | 用户手动"Load collection"从数据库导入的表，结构完全由数据库端决定 | ✅ 应该同步（修复前错误排除） |

**前后端不一致性：** 前端同步按钮的显示条件只排除 `db2cm`/`view`/`sql`（见 `plugin-data-source-manager` 的 `SyncFieldChangesAction.tsx`），`dbsync` 表的同步按钮**可见且可点击**，但后端实际处理时丢弃了 `dbsync`，形成**静默失败**。

### ✅ 修复内容

将 `getLoadedCollections()` 过滤条件仅保留 `db2cm`，移除 `dbsync`：

```diff
const collections = loadedCollections.filter(

(collection: Model) => !['db2cm', 'dbsync'].includes(collection.options?.from),
(collection: Model) => !['db2cm'].includes(collection.options?.from), );

### 📁 Files changed

- `packages/core/server/src/main-data-source.ts`（1 处修改）

🧪 Test suggestion / 测试建议
建议补充 packages/plugins/@nocobase/plugin-data-source-main/src/server/__tests__/read-db-tables.test.ts 增加一个基于 loadTables（from=dbsync`场景的测试用例：
先用 queryInterface.createTable建表
用 mainDataSource.loadTables(ctx, [tableName])导入（形成 from=dbsync）
用 queryInterface.addColumn/removeColumn 改表结构
调用 api.resource('mainDataSource').syncFields(...)
断言 fields 表中能查到新增字段，已写入或字段已消失