### PR TITLE
fix(plugin-workflow): fix variable level in filter

### DIFF
--- a/packages/core/client-v2/src/flow/components/filter/VariableFilterItem.tsx
+++ b/packages/core/client-v2/src/flow/components/filter/VariableFilterItem.tsx
@@ -139,9 +139,16 @@ export interface VariableFilterItemProps {
   rightVariableConverters?: Pick<Converters, 'resolvePathFromValue' | 'resolveValueFromPath'>;
   ignoreFieldNames?: string[];
   maxAssociationFieldDepth?: number;
+  /**
+   * 右侧变量树的关联层级上限，默认与 `maxAssociationFieldDepth` 一致。
+   * 传 `null` 表示不限制：右侧是变量树而非集合字段树，其深度可能已由调用方约束
+   * （例如工作流的变量树由触发器的「预加载关系数据」决定），此时再按左侧的层级上限裁剪
+   * 会让已配置好的深层变量选不到。
+   */
+  rightMaxAssociationFieldDepth?: number | null;
 }
 
-function limitMetaTreeIfNeeded(nodes: MetaTreeNode[], maxAssociationFieldDepth?: number) {
+function limitMetaTreeIfNeeded(nodes: MetaTreeNode[], maxAssociationFieldDepth?: number | null) {
   if (typeof maxAssociationFieldDepth !== 'number') {
     return nodes;
   }
@@ -367,6 +374,7 @@ export const VariableFilterItem: React.FC<VariableFilterItemProps> = observer(
     rightVariableConverters,
     ignoreFieldNames,
     maxAssociationFieldDepth,
+    rightMaxAssociationFieldDepth = maxAssociationFieldDepth,
   }) => {
     // 使用 View 上下文，确保可访问 ctx.view 的异步子树
     const ctx = useFlowViewContext();
@@ -685,10 +693,10 @@ export const VariableFilterItem: React.FC<VariableFilterItemProps> = observer(
             { title: t('Null'), name: 'null', type: 'object', paths: ['null'], render: NullComponent },
             ...nodes,
           ],
-          maxAssociationFieldDepth,
+          rightMaxAssociationFieldDepth,
         );
       };
-    }, [rightMetaTree, ctx, staticInputRenderer, NullComponent, t, maxAssociationFieldDepth]);
+    }, [rightMetaTree, ctx, staticInputRenderer, NullComponent, t, rightMaxAssociationFieldDepth]);
 
     // 当启用右侧变量输入时，构造 VariableInput 的 converters：
     // - 变量模式：返回 null 让 VariableInput 渲染 VariableTag

--- a/packages/core/client-v2/src/flow/components/filter/__tests__/VariableFilterItem.rightMetaTree.test.tsx
+++ b/packages/core/client-v2/src/flow/components/filter/__tests__/VariableFilterItem.rightMetaTree.test.tsx
@@ -1,0 +1,158 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import type { MetaTreeNode } from '@nocobase/flow-engine';
+import { FlowEngine, FlowModel } from '@nocobase/flow-engine';
+import { VariableFilterItem } from '../VariableFilterItem';
+import { createMockFlowApp, TestCollectionFieldInterface } from '../../../__tests__/helpers/mockFlowApp';
+
+const captured = vi.hoisted(() => ({ metaTrees: [] as any[] }));
+
+vi.mock('@nocobase/flow-engine', async () => {
+  const actual = await vi.importActual<any>('@nocobase/flow-engine');
+  const MockVariableInput = ({ onChange, metaTree }: any) => {
+    if (metaTree) {
+      captured.metaTrees.push(metaTree);
+    }
+    return (
+      <button
+        type="button"
+        data-testid="variable-input"
+        onClick={() =>
+          onChange?.('title', {
+            interface: 'input',
+            uiSchema: { 'x-component': 'Input' },
+            paths: ['collection', 'title'],
+          })
+        }
+      >
+        mock-variable-input
+      </button>
+    );
+  };
+  return { ...actual, VariableInput: MockVariableInput };
+});
+
+// $context.data (not an association) -> category (m2o) -> book (m2o) -> createdBy (not counted) -> departments (m2m).
+// Mirrors a workflow collection-event trigger that preloads `category.book.createdBy.departments`.
+function buildRightMetaTree(): MetaTreeNode[] {
+  const departments: MetaTreeNode = {
+    name: 'departments',
+    title: 'Departments',
+    type: 'object',
+    interface: 'm2m',
+    paths: ['$context', 'data', 'category', 'book', 'createdBy', 'departments'],
+  };
+  const createdBy: MetaTreeNode = {
+    name: 'createdBy',
+    title: 'Created by',
+    type: 'object',
+    interface: 'createdBy',
+    paths: ['$context', 'data', 'category', 'book', 'createdBy'],
+    children: async () => [departments],
+  };
+  const book: MetaTreeNode = {
+    name: 'book',
+    title: 'Book',
+    type: 'object',
+    interface: 'obo',
+    paths: ['$context', 'data', 'category', 'book'],
+    children: async () => [createdBy],
+  };
+  const category: MetaTreeNode = {
+    name: 'category',
+    title: 'Category',
+    type: 'object',
+    interface: 'm2o',
+    paths: ['$context', 'data', 'category'],
+    children: async () => [book],
+  };
+  const data: MetaTreeNode = {
+    name: 'data',
+    title: 'Trigger data',
+    type: 'object',
+    paths: ['$context', 'data'],
+    children: async () => [category],
+  };
+  return [{ name: '$context', title: 'Trigger variables', type: '', paths: ['$context'], children: [data] }];
+}
+
+async function resolveChildren(node: MetaTreeNode | undefined) {
+  const children = node?.children;
+  if (typeof children === 'function') {
+    return (await (children as () => Promise<MetaTreeNode[]>)()) ?? [];
+  }
+  return Array.isArray(children) ? children : [];
+}
+
+async function walkToCreatedByChildren(metaTree: any) {
+  const roots: MetaTreeNode[] = typeof metaTree === 'function' ? await metaTree() : metaTree;
+  const context = roots.find((node) => node.name === '$context');
+  const data = (await resolveChildren(context)).find((node) => node.name === 'data');
+  const category = (await resolveChildren(data)).find((node) => node.name === 'category');
+  const book = (await resolveChildren(category)).find((node) => node.name === 'book');
+  const createdBy = (await resolveChildren(book)).find((node) => node.name === 'createdBy');
+  return (await resolveChildren(createdBy)).map((node) => node.name);
+}
+
+function createModel() {
+  const engine = new FlowEngine();
+  const model = new FlowModel({ uid: 'm-variable-filter-right', flowEngine: engine });
+  const app = createMockFlowApp();
+  model.context.defineProperty('app', { value: app });
+
+  class InputInterface extends TestCollectionFieldInterface {
+    name = 'input';
+    group = 'basic';
+    filterable = { operators: [{ value: '$eq', label: 'Equals' }] };
+  }
+  app.addFieldInterfaces([InputInterface]);
+
+  const ds = engine.dataSourceManager.getDataSource('main');
+  ds.addCollection({
+    name: 'posts',
+    fields: [{ name: 'title', type: 'string', interface: 'input', uiSchema: { 'x-component': 'Input' } }],
+  });
+  model.context.defineProperty('collection', { get: () => ds.getCollection('posts') });
+
+  return model as any;
+}
+
+function renderItem(props: Record<string, unknown>) {
+  const value = { path: 'title', operator: '$eq', value: '' } as any;
+  const model = createModel();
+  render(
+    <VariableFilterItem value={value} model={model} rightAsVariable rightMetaTree={buildRightMetaTree()} {...props} />,
+  );
+  fireEvent.click(screen.getAllByTestId('variable-input')[0]);
+  return captured.metaTrees.at(-1);
+}
+
+describe('VariableFilterItem right-side association depth', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    captured.metaTrees = [];
+  });
+
+  it('applies maxAssociationFieldDepth to the right tree by default', async () => {
+    const metaTree = renderItem({ maxAssociationFieldDepth: 2 });
+    // `departments` is the third association down the path, so the default cap removes it.
+    expect(await walkToCreatedByChildren(metaTree)).toEqual([]);
+  });
+
+  // The right side is a variable tree whose depth is decided by its provider (in workflow, by the trigger's
+  // "Preload associations" config). Capping it by the left-side field-picker limit hid preloaded variables.
+  it('leaves the right tree untouched when rightMaxAssociationFieldDepth is null', async () => {
+    const metaTree = renderItem({ maxAssociationFieldDepth: 2, rightMaxAssociationFieldDepth: null });
+    expect(await walkToCreatedByChildren(metaTree)).toEqual(['departments']);
+  });
+});

--- a/packages/core/client/src/schema-component/antd/appends-tree-select/AppendsTreeSelect.tsx
+++ b/packages/core/client/src/schema-component/antd/appends-tree-select/AppendsTreeSelect.tsx
@@ -175,8 +175,10 @@ export const FieldsTreeSelect: React.FC<TreeSelectProps & AppendsTreeSelectProps
         }
         const next = paths.slice(0, i + 1).join('.');
         if (optionsMap[next]) {
+          // NOTE: already loaded, keep walking down instead of stopping, otherwise the deeper levels of the path are
+          // never loaded and the value silently disappears from the selector
           option = optionsMap[next];
-          break;
+          continue;
         }
         if (!option.isLeaf && option.loadChildren) {
           const children = option.loadChildren(option);

--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/canvas/__tests__/collectionFieldOptions.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/canvas/__tests__/collectionFieldOptions.test.ts
@@ -148,4 +148,86 @@ describe('getCollectionFieldOptions (client-v2)', () => {
     expect(getCollectionFieldOptions({ compile, collectionManager })).toEqual([]);
     expect(collectionManager.getCollectionAllFields).not.toHaveBeenCalled();
   });
+
+  describe('deeply nested appends', () => {
+    // A chain c0 -> c1 -> ... -> c5, each level linked by a `next` belongsTo, mirroring a collection-event trigger
+    // whose "Preload associations" config goes several levels deep.
+    const chain: Record<string, MockField[]> = {};
+    for (let i = 0; i <= 5; i++) {
+      chain[`c${i}`] = [
+        { name: 'id', type: 'bigInt', interface: 'integer', uiSchema: { title: 'ID' }, primaryKey: true },
+        { name: `name${i}`, type: 'string', interface: 'input', uiSchema: { title: `Name${i}` } },
+        ...(i < 5
+          ? [
+              {
+                name: 'next',
+                type: 'belongsTo',
+                interface: 'm2o',
+                target: `c${i + 1}`,
+                targetKey: 'id',
+                foreignKey: 'nextId',
+                uiSchema: { title: 'Next' },
+              } as MockField,
+              {
+                name: 'nextId',
+                type: 'bigInt',
+                interface: 'integer',
+                foreignKey: 'nextId',
+                isForeignKey: true,
+                uiSchema: { title: 'Next ID' },
+              } as MockField,
+            ]
+          : []),
+      ];
+    }
+
+    // Walk the tree the way the variable picker does: expand `next` level by level, returning the paths reached.
+    function walk(configAppends: string[], types?: any[]) {
+      const collectionManager = makeCollectionManager(chain);
+      const options = getCollectionFieldOptions({
+        types,
+        // Same shape the collection trigger builds: the record itself plus every configured path under it.
+        appends: ['data', ...configAppends.map((item) => `data.${item}`)],
+        fields: [
+          { collectionName: 'c0', name: 'data', type: 'hasOne', target: 'c0', uiSchema: { title: 'Trigger data' } },
+        ],
+        compile,
+        collectionManager,
+      });
+      const reached: string[] = [];
+      const path = ['data'];
+      let current: any = options.find((o) => o.value === 'data');
+      while (current) {
+        reached.push(path.join('.'));
+        if (current.isLeaf || !current.loadChildren) {
+          break;
+        }
+        current.loadChildren(current);
+        current = (current.children ?? []).find((child: any) => child.value === 'next');
+        path.push('next');
+      }
+      return reached;
+    }
+
+    const full = ['next', 'next.next', 'next.next.next', 'next.next.next.next'];
+    const gapped = ['next', 'next.next', 'next.next.next.next']; // `next.next.next` missing from the config
+    const leafOnly = ['next.next.next.next'];
+    const allLevels = ['data', 'data.next', 'data.next.next', 'data.next.next.next', 'data.next.next.next.next'];
+
+    it('walks every configured level', () => {
+      expect(walk(full)).toEqual(allLevels);
+    });
+
+    // A nested appends entry preloads the whole chain server-side, so a missing intermediate entry must not cut the
+    // variable tree short — it used to stop at the gap, making deeper variables unselectable.
+    it('walks past gaps in the configured paths', () => {
+      expect(walk(gapped)).toEqual(allLevels);
+      expect(walk(leafOnly)).toEqual(allLevels);
+    });
+
+    it('walks past gaps with a type filter as well', () => {
+      expect(walk(gapped, ['string'])).toEqual(allLevels);
+      expect(walk(leafOnly, ['string'])).toEqual(allLevels);
+    });
+  });
 });

--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/canvas/collectionFieldOptions.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/canvas/collectionFieldOptions.ts
@@ -139,6 +139,16 @@ function getNextAppends(field, appends: string[] | null): string[] | null {
   return appends.filter((item) => item.startsWith(fieldPrefix)).map((item) => item.replace(fieldPrefix, ''));
 }
 
+/**
+ * Whether an association field is preloaded by `appends`. A nested entry such as `a.b.c` makes the whole chain
+ * available — that is how the server resolves appends — so a field that only appears as a path prefix counts as
+ * appended even when its own path is not a separate entry. Without this, a config with any gap in the chain (e.g.
+ * `['a', 'a.b', 'a.b.c.d.e']`) stops the variable tree at the gap while the data itself is fully loaded.
+ */
+function isAppended(field, appends: string[], nextAppends: string[] | null): boolean {
+  return appends.includes(field.name) || Boolean(nextAppends?.length);
+}
+
 function filterTypedFields({ fields, types, appends, depth = 1, compile, collectionManager }) {
   return fields.filter((field) => {
     const match = types?.length ? types.some((type) => matchFieldType(field, type, { collectionManager })) : true;
@@ -160,12 +170,12 @@ function filterTypedFields({ fields, types, appends, depth = 1, compile, collect
         );
       }
       const nextAppends = getNextAppends(field, appends);
-      const included = appends.includes(field.name);
+      const included = isAppended(field, appends, nextAppends);
       if (match) {
         return included;
       } else {
         return (
-          (nextAppends?.length || included) &&
+          included &&
           filterTypedFields({
             fields: getNormalizedFields(field.target, { compile, collectionManager }),
             types,
@@ -304,8 +314,7 @@ export function getCollectionFieldOptions(options): VariableOption[] {
     const label = compile(field.uiSchema?.title || field.name);
     const nextAppends = getNextAppends(field, appends);
     // TODO: no matching fields in next appends should consider isLeaf as true
-    const isLeaf =
-      !isAssociationField(field) || (nextAppends && !nextAppends.length && !appends.includes(field.name)) || false;
+    const isLeaf = !isAssociationField(field) || (appends != null && !isAppended(field, appends, nextAppends));
 
     return {
       [fieldNames.label]: label,

--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/FilterDynamicComponent.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/FilterDynamicComponent.tsx
@@ -377,6 +377,10 @@ export function FilterDynamicComponent({
           rightMetaTree={rightMetaTree}
           rightVariableConverters={workflowFilterVariableConverters}
           maxAssociationFieldDepth={maxAssociationFieldDepth}
+          // The right-hand tree is the workflow variable tree, whose depth is already decided by the trigger's
+          // "Preload associations" config — capping it by the left-side field-picker limit would hide variables the
+          // user has explicitly preloaded.
+          rightMaxAssociationFieldDepth={null}
         />
       </FlowModelProvider>
     );

--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/__tests__/FilterDynamicComponent.test.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/__tests__/FilterDynamicComponent.test.tsx
@@ -207,6 +207,28 @@ describe('FilterDynamicComponent', () => {
     expect(testState.variableFilterItems.at(-1)?.maxAssociationFieldDepth).toBe(2);
   });
 
+  // The left-side field picker walks the queried collection's relations and is capped for sanity; the right-side tree
+  // is the workflow variable tree, whose depth is decided by the trigger's "Preload associations" config. Capping the
+  // right side too made preloaded variables deeper than two associations unselectable.
+  it('leaves the right-side variable tree unlimited regardless of the left-side cap', () => {
+    const { engine } = setupEngine();
+
+    render(
+      <FlowEngineProvider engine={engine}>
+        <FilterDynamicComponent
+          collection="posts"
+          value={{ $and: [{ title: { $eq: 'foo' } }] }}
+          onChange={() => undefined}
+          maxAssociationFieldDepth={2}
+        />
+      </FlowEngineProvider>,
+    );
+
+    const last = testState.variableFilterItems.at(-1);
+    expect(last?.maxAssociationFieldDepth).toBe(2);
+    expect(last?.rightMaxAssociationFieldDepth).toBeNull();
+  });
+
   it('passes through a custom maxAssociationFieldDepth when consumers override it', () => {
     const { engine } = setupEngine();
 

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/triggers/CollectionTrigger.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/triggers/CollectionTrigger.ts
@@ -70,7 +70,7 @@ export default class CollectionTrigger extends Trigger {
       then: Joi.array().items(Joi.string()).optional(),
       otherwise: Joi.forbidden(),
     }),
-    condition: Joi.object(),
+    condition: Joi.object().allow(null),
     rollbackOnFailure: Joi.boolean().optional(),
     appends: Joi.when('mode', {
       is: (mode) => mode !== MODE_BITMAP.DESTROY,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed the issue where variables nested deeper than three levels cannot be used in workflow query node conditions |
| 🇨🇳 Chinese | 修复工作流查询节点条件中无法使用超过三层变量的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
