### PR TITLE
fix(plugin-file-previewer-office): fix file url

### DIFF
--- a/packages/plugins/@nocobase/plugin-file-previewer-office/src/client-v2/__tests__/utils.test.ts
+++ b/packages/plugins/@nocobase/plugin-file-previewer-office/src/client-v2/__tests__/utils.test.ts
@@ -179,6 +179,36 @@ describe('resolveTemporaryOfficeFileUrl', () => {
     expect(request).not.toHaveBeenCalled();
   });
 
+  it('passes original storage URLs of managed records through without requesting a token', async () => {
+    const request = vi.fn();
+
+    await expect(
+      resolveTemporaryOfficeFileUrl(
+        { request },
+        {
+          id: 76,
+          storageId: 385880225087488,
+          url: 'https://bucket.s3.us-west-1.amazonaws.com/contract.docx?X-Amz-Signature=xxxx',
+        },
+        { dataSourceKey: 'main', collectionName: 'attachments' },
+      ),
+    ).resolves.toBe('https://bucket.s3.us-west-1.amazonaws.com/contract.docx?X-Amz-Signature=xxxx');
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  it('passes public same-origin storage URLs through without requesting a token', async () => {
+    const request = vi.fn();
+
+    await expect(
+      resolveTemporaryOfficeFileUrl(
+        { request },
+        { id: 42, storageId: 1, url: '/storage/uploads/report.xlsx' },
+        { dataSourceKey: 'main', collectionName: 'attachments' },
+      ),
+    ).resolves.toBe(`${window.location.origin}/storage/uploads/report.xlsx`);
+    expect(request).not.toHaveBeenCalled();
+  });
+
   it('falls back to permanent URL metadata when collection context is unavailable', async () => {
     const request = vi.fn().mockResolvedValue({
       data: { url: '/files/main/main/attachments/42.xlsx?temporaryAccessToken=signed' },

--- a/packages/plugins/@nocobase/plugin-file-previewer-office/src/client-v2/utils.ts
+++ b/packages/plugins/@nocobase/plugin-file-previewer-office/src/client-v2/utils.ts
@@ -135,6 +135,13 @@ export const resolveTemporaryOfficeFileUrl = async (
   file: OfficePreviewFile,
   fileCollection?: FileCollectionReference,
 ): Promise<string> => {
+  // Only permanent file access URLs (`/files/...` on the current origin) need a temporary token to be readable by the
+  // external Office viewer. Original URLs and public storage URLs are already reachable, so they are passed through.
+  const permanentAccessParams = parsePermanentFileUrl(file);
+  if (!permanentAccessParams) {
+    return resolveFileUrl(file);
+  }
+
   let accessParams: Pick<PermanentFileAccessParams, 'dataSourceKey' | 'collectionName' | 'id'>;
   let headers: Record<string, string>;
 
@@ -146,11 +153,7 @@ export const resolveTemporaryOfficeFileUrl = async (
     };
     headers = { 'X-Data-Source': accessParams.dataSourceKey };
   } else {
-    const permanentAccessParams = parsePermanentFileUrl(file);
-    if (
-      !permanentAccessParams ||
-      (fileCollection && permanentAccessParams.collectionName !== fileCollection.collectionName)
-    ) {
+    if (fileCollection && permanentAccessParams.collectionName !== fileCollection.collectionName) {
       return resolveFileUrl(file);
     }
     accessParams = permanentAccessParams;


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Fixed the issue with incorrect URLs being used for Office file previews.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed the issue with incorrect URLs being used for Office file previews |
| 🇨🇳 Chinese | 修复 Office 文件预览文件 URL 使用错误的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
