### PR TITLE
feat(plugin-field-formula): add DateOnly storage type

### DIFF
--- a/packages/plugins/@nocobase/plugin-field-formula/src/client-v2/interfaces/formula.tsx
+++ b/packages/plugins/@nocobase/plugin-field-formula/src/client-v2/interfaces/formula.tsx
@@ -40,7 +40,8 @@ export const formulaDateOperators = resolveFilterOperators('datetime').filter(
   (operator) => !['$dateNotBefore', '$dateNotAfter'].includes(operator.value),
 );
 
-const isDateFormula = ({ getValue }: FieldConfigureEffectContext) => getValue('dataType') === 'date';
+const isDateFormula = ({ getValue }: FieldConfigureEffectContext) =>
+  ['date', 'dateOnly'].includes(String(getValue('dataType')));
 const isNumberFormula = ({ getValue }: FieldConfigureEffectContext) =>
   ['double', 'decimal'].includes(String(getValue('dataType')));
 
@@ -87,6 +88,7 @@ export class FormulaFieldInterface extends CollectionFieldInterface {
           { value: 'double', label: 'Double' },
           { value: 'string', label: 'String' },
           { value: 'date', label: 'Datetime' },
+          { value: 'dateOnly', label: 'Date' },
         ],
         required: true,
         defaultValue: 'double',

--- a/packages/plugins/@nocobase/plugin-field-formula/src/client/interfaces/formula.tsx
+++ b/packages/plugins/@nocobase/plugin-field-formula/src/client/interfaces/formula.tsx
@@ -39,7 +39,7 @@ const datetimeReactions = [
     dependencies: ['dataType'],
     fulfill: {
       state: {
-        display: '{{$deps[0] === "date" ? "visible" : "none"}}',
+        display: '{{$deps[0] === "date" || $deps[0] === "dateOnly" ? "visible" : "none"}}',
       },
     },
   },
@@ -126,6 +126,7 @@ export class FormulaFieldInterface extends CollectionFieldInterface {
         // { value: 'decimal', label: 'Decimal' }, // not supported
         { value: 'string', label: 'String' },
         { value: 'date', label: 'Datetime' },
+        { value: 'dateOnly', label: 'Date' },
       ],
       required: true,
       default: 'double',

--- a/packages/plugins/@nocobase/plugin-field-formula/src/server/formula-field.ts
+++ b/packages/plugins/@nocobase/plugin-field-formula/src/server/formula-field.ts
@@ -25,6 +25,7 @@ const DataTypeMap = {
   decimal: DataTypes.DECIMAL,
   string: DataTypes.STRING,
   date: DataTypes.DATE(3),
+  dateOnly: DataTypes.DATEONLY,
 };
 
 export class FormulaField extends Field {

--- a/packages/plugins/@nocobase/plugin-field-formula/src/utils/__tests__/index.test.ts
+++ b/packages/plugins/@nocobase/plugin-field-formula/src/utils/__tests__/index.test.ts
@@ -1,0 +1,16 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { toDbType } from '../index';
+
+describe('formula field value conversion', () => {
+  it('converts dates to calendar dates for dateOnly storage', () => {
+    expect(toDbType(new Date(2026, 3, 15, 12), 'dateOnly')).toBe('2026-04-15');
+  });
+});

--- a/packages/plugins/@nocobase/plugin-field-formula/src/utils/index.ts
+++ b/packages/plugins/@nocobase/plugin-field-formula/src/utils/index.ts
@@ -148,6 +148,14 @@ export const DataTypeTransformers = {
       return new Date(value);
     },
   },
+  dateOnly: {
+    date(value: Date) {
+      const year = value.getFullYear();
+      const month = String(value.getMonth() + 1).padStart(2, '0');
+      const day = String(value.getDate()).padStart(2, '0');
+      return `${year}-${month}-${day}`;
+    },
+  },
 };
 
 export function toDbType(value: any, type: string) {


### PR DESCRIPTION
### This is a ...
- [x] New feature
- [x] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Formula fields had no DateOnly storage type, so calendar dates coming from DateOnly sources were stored as timestamps and shifted across timezone boundaries.

### Description
Adds `dateOnly` as a storage type for Formula fields: it is exposed in the field editor (both client versions), mapped to `DATEONLY` on the server, and converted to a `YYYY-MM-DD` calendar date by the formula utilities. The existing Datetime (`date`) behavior is unchanged. A unit test covers the date conversion.

### Related issues
Refs #9145 — this implements the DateOnly storage option requested there.

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### Docs

| Language   | Link |
| ---------- | ---- |
| 🇺🇸 English |      |
| 🇨🇳 Chinese |      |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary

